### PR TITLE
fix: reopen hidden activity bar views

### DIFF
--- a/packages/page-object/src/parts/ActivityBar/ActivityBar.ts
+++ b/packages/page-object/src/parts/ActivityBar/ActivityBar.ts
@@ -247,11 +247,16 @@ export const create = ({ electronApp, expect, ideVersion, page, platform, VError
         await page.waitForIdle()
         const activityBarItem = activityBar.locator(`.action-item:has(.action-label[aria-label^="${ariaLabel}"])`)
         const expanded = await activityBarItem.getAttribute('aria-expanded')
-        if (expanded === 'false') {
+        const sideBar = page.locator('.sidebar')
+        const sideBarVisible = await sideBar.isVisible()
+        if (!sideBarVisible) {
+          await activityBarItem.clickExponential({
+            waitFor: sideBar,
+          })
+        } else if (expanded === 'false') {
           await activityBarItem.click()
         }
         await page.waitForIdle()
-        const sideBar = page.locator('.sidebar')
         const title = sideBar.locator('.composite.title')
         await expect(title).toHaveText(titleLabel)
         await page.waitForIdle()


### PR DESCRIPTION
Retry activity-bar clicks until a hidden sidebar has actually reopened. This keeps repeated view-switch runs from reading an empty sidebar title when the initial click is ignored.