### PR TITLE
fix: wait longer for performance profile

### DIFF
--- a/packages/page-object/src/parts/RunAndDebug/RunAndDebug.ts
+++ b/packages/page-object/src/parts/RunAndDebug/RunAndDebug.ts
@@ -433,7 +433,7 @@ export const create = ({ electronApp, expect, ideVersion, page, platform, VError
         await page.waitForIdle()
         const decoration = page.locator('.monaco-editor .codelens-decoration', {})
         await expect(decoration).toBeVisible({
-          timeout: 5000,
+          timeout: 15_000,
         })
         await page.waitForIdle()
         await expect(decoration).toHaveText(/Self Time/)


### PR DESCRIPTION
Increase the CPU profile CodeLens wait to match the existing CodeLens timeout used elsewhere. This prevents the focused debug performance profile e2e test from timing out while VS Code renders the saved profile under CI load.