### PR TITLE
fix: allow closing notifications without options

### DIFF
--- a/packages/page-object/src/parts/Notification/Notification.ts
+++ b/packages/page-object/src/parts/Notification/Notification.ts
@@ -4,7 +4,7 @@ import * as WellKnownCommands from '../WellKnownCommands/WellKnownCommands.ts'
 
 export const create = ({ electronApp, expect, ideVersion, page, platform, VError }: CreateParams) => {
   return {
-    async closeAll({ force = false }) {
+    async closeAll({ force = false } = {}) {
       try {
         await page.waitForIdle()
         const toastContainer = page.locator('.notifications-toasts')


### PR DESCRIPTION
Fix the notification page object so its optional close options can be omitted. This prevents source-definition-not-found and other notification tests from throwing before closing the notification.