### PR TITLE
fix: position cursor on html tag for hover

### DIFF
--- a/packages/e2e/src/editor-hover-toggle.ts
+++ b/packages/e2e/src/editor-hover-toggle.ts
@@ -14,7 +14,7 @@ export const setup = async ({ Editor, Explorer, Workspace }: TestContext): Promi
   await Explorer.refresh()
   await Explorer.shouldHaveItem('index.html')
   await Editor.open('index.html')
-  await Editor.setCursor(1, 1)
+  await Editor.setCursor(1, 2)
   await Editor.shouldHaveBreadCrumb('index.html')
   await Editor.shouldHaveBreadCrumb('h1')
 }


### PR DESCRIPTION
Positions the editor cursor on the HTML tag before invoking Show or Focus Hover so the HTML language hover is available on VS Code 1.127.