### PR TITLE
feature: try event listener stack trace measure

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-26, windows-2022]
-    timeout-minutes: 240
+    timeout-minutes: 360
     steps:
       - uses: actions/checkout@v7
       - run: |
@@ -81,6 +81,11 @@ jobs:
         uses: coactions/setup-xvfb@v1
         with:
           run: node packages/cli/bin/test.js --cwd packages/e2e --check-leaks --measure event-listeners
+      - name: Run headless test (check leaks, event listeners with stack traces)
+        if: matrix.os == 'ubuntu-24.04'
+        uses: coactions/setup-xvfb@v1
+        with:
+          run: node packages/cli/bin/test.js --cwd packages/e2e --check-leaks --measure event-listeners-with-stack-trace --runs 37 --restart-between --measure-after --run-skipped-tests-anyway
       - name: Generate charts
         run: node packages/charts/src/main.ts
       - uses: actions/upload-artifact@v7


### PR DESCRIPTION
Run nearly all e2e tests with the event-listener stack-trace leak measure over 37 restarted runs.