### PR TITLE
fix: stabilize JavaScript performance profile test

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,51 @@ on:
       - main
 
 jobs:
+  debug-javascript-performance-profile:
+    name: Debug JavaScript performance profile (attempt ${{ matrix.attempt }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        attempt: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+      - name: Compute node modules cache key
+        id: nodeModulesCacheKey
+        run: echo "value=$(node scripts/computeNodeModulesCacheKey.js)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v6
+        id: npm-cache
+        with:
+          path: |
+            **/node_modules
+            **/.vscode-test
+            **/.vscode-user-data-dir
+            **/.vscode-ffmpeg
+            **/.vscode-resolve-source-map-cache
+          key: ${{ runner.os }}-cacheNodeModules-${{ steps.nodeModulesCacheKey.outputs.value }}
+      - name: npm ci
+        run: npm ci --ignore-scripts && npm run postinstall
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+      - run: npm run build
+      - name: Run targeted attempt
+        uses: coactions/setup-xvfb@v1
+        with:
+          run: >-
+            node packages/cli/bin/test.js
+            --cwd packages/e2e
+            --only debug-javascript-performance-profile.ts
+            --run-skipped-tests-anyway
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: debug-javascript-performance-profile-attempt-${{ matrix.attempt }}
+          path: ./.vscode-videos
+          include-hidden-files: true
+
   pr:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/packages/page-object/src/parts/QuickPick/QuickPick.ts
+++ b/packages/page-object/src/parts/QuickPick/QuickPick.ts
@@ -15,16 +15,19 @@ export const create = ({ expect, page, platform, VError }: CreateParams) => {
       command: string,
       {
         pressKeyOnce = false,
+        skipIdle = false,
         stayVisible = false,
         stopsApplication = false,
-      }: { pressKeyOnce?: boolean; stayVisible?: boolean | 'dont-care'; stopsApplication?: boolean } = {},
+      }: { pressKeyOnce?: boolean; skipIdle?: boolean; stayVisible?: boolean | 'dont-care'; stopsApplication?: boolean } = {},
     ) {
       try {
-        await page.waitForIdle()
-        await this.showCommands({ pressKeyOnce })
-        await this.type(command)
-        await this.select(command, stayVisible, stopsApplication)
-        if (!stopsApplication) {
+        if (!skipIdle) {
+          await page.waitForIdle()
+        }
+        await this.showCommands({ pressKeyOnce, skipIdle })
+        await this.type(command, { skipIdle })
+        await this.select(command, stayVisible, stopsApplication, { skipIdle })
+        if (!stopsApplication && !skipIdle) {
           await page.waitForIdle()
         }
       } catch (error) {
@@ -133,9 +136,16 @@ export const create = ({ expect, page, platform, VError }: CreateParams) => {
         throw new VError(error, `Failed to press Enter`)
       }
     },
-    async select(text: string | RegExp, stayVisible: boolean | 'dont-care' = false, stopsApplication = false) {
+    async select(
+      text: string | RegExp,
+      stayVisible: boolean | 'dont-care' = false,
+      stopsApplication = false,
+      { skipIdle = false }: { skipIdle?: boolean } = {},
+    ) {
       try {
-        await page.waitForIdle()
+        if (!skipIdle) {
+          await page.waitForIdle()
+        }
         const quickPick = page.locator('.quick-input-widget')
         await expect(quickPick).toBeVisible()
         let selectedAt: number
@@ -144,14 +154,18 @@ export const create = ({ expect, page, platform, VError }: CreateParams) => {
             hasExactText: text,
           })
           await expect(option).toBeVisible()
-          await page.waitForIdle()
+          if (!skipIdle) {
+            await page.waitForIdle()
+          }
           selectedAt = performance.timeOrigin + performance.now()
           await option.click()
         } else {
           const normal = `${text}`.slice(1, -1)
           const item = quickPick.locator(`.monaco-list-row[aria-label*="${normal}"]`)
           await expect(item).toBeVisible()
-          await page.waitForIdle()
+          if (!skipIdle) {
+            await page.waitForIdle()
+          }
           const label = item.locator('.label-name')
           selectedAt = performance.timeOrigin + performance.now()
           await label.click()
@@ -159,7 +173,7 @@ export const create = ({ expect, page, platform, VError }: CreateParams) => {
         if (!stayVisible) {
           await expect(quickPick).toBeHidden()
         }
-        if (!stopsApplication) {
+        if (!stopsApplication && !skipIdle) {
           await page.waitForIdle()
         }
         return selectedAt
@@ -167,9 +181,11 @@ export const create = ({ expect, page, platform, VError }: CreateParams) => {
         throw new VError(error, `Failed to select "${text}"`)
       }
     },
-    async show({ key = KeyBindings.getOpenQuickPickFiles(platform), pressKeyOnce = false } = {}) {
+    async show({ key = KeyBindings.getOpenQuickPickFiles(platform), pressKeyOnce = false, skipIdle = false } = {}) {
       try {
-        await page.waitForIdle()
+        if (!skipIdle) {
+          await page.waitForIdle()
+        }
         const quickPick = page.locator('.quick-input-widget')
         // TODO there might be a conflict here when pressing the keyboard shortcut
         // too often, the quickpick opens, making the next statement pass
@@ -186,7 +202,9 @@ export const create = ({ expect, page, platform, VError }: CreateParams) => {
           timeout: 10_000,
         })
         await expect(quickPick).toBeVisible()
-        await page.waitForIdle()
+        if (!skipIdle) {
+          await page.waitForIdle()
+        }
         await this.waitForInputVisible()
       } catch (error) {
         throw new VError(error, `Failed to show quick pick`)
@@ -201,9 +219,9 @@ export const create = ({ expect, page, platform, VError }: CreateParams) => {
         throw new VError(error, `Failed to show quick pick color theme`)
       }
     },
-    async showCommands({ pressKeyOnce = false } = {}) {
+    async showCommands({ pressKeyOnce = false, skipIdle = false } = {}) {
       try {
-        return this.show({ key: KeyBindings.getOpenQuickPickCommands(platform || ''), pressKeyOnce })
+        return this.show({ key: KeyBindings.getOpenQuickPickCommands(platform || ''), pressKeyOnce, skipIdle })
       } catch (error) {
         throw new VError(error, `Failed to show quick pick`)
       }
@@ -217,11 +235,13 @@ export const create = ({ expect, page, platform, VError }: CreateParams) => {
         throw new VError(error, `Failed to show quick pick file icon theme`)
       }
     },
-    async type(value: string) {
+    async type(value: string, { skipIdle = false }: { skipIdle?: boolean } = {}) {
       try {
         const quickPickInput = await this.waitForInputVisible()
         await quickPickInput.type(value)
-        await page.waitForIdle()
+        if (!skipIdle) {
+          await page.waitForIdle()
+        }
       } catch (error) {
         throw new VError(error, `Failed to type ${value}`)
       }

--- a/packages/page-object/src/parts/RunAndDebug/RunAndDebug.ts
+++ b/packages/page-object/src/parts/RunAndDebug/RunAndDebug.ts
@@ -406,7 +406,6 @@ export const create = ({ electronApp, expect, ideVersion, page, platform, VError
     },
     async takeCpuProfile({ seconds }: { seconds: number }) {
       try {
-        await page.waitForIdle()
         const quickPick = QuickPick.create({
           electronApp,
           expect,
@@ -417,27 +416,24 @@ export const create = ({ electronApp, expect, ideVersion, page, platform, VError
         })
         await quickPick.executeCommand('Debug: Take Performance Profile', {
           pressKeyOnce: true,
+          skipIdle: true,
           stayVisible: true,
         })
-        await quickPick.select('CPU Profile', true)
-        await page.waitForIdle()
-        await quickPick.select('Manual', false)
-        await page.waitForIdle()
+        await quickPick.select('CPU Profile', true, false, { skipIdle: true })
+        await quickPick.select('Manual', false, false, { skipIdle: true })
         await new Promise((r) => {
           setTimeout(r, seconds * 1000)
         })
         await quickPick.executeCommand('Debug: Stop Performance Profile', {
           pressKeyOnce: true,
+          skipIdle: true,
           stayVisible: false,
         })
-        await page.waitForIdle()
         const decoration = page.locator('.monaco-editor .codelens-decoration', {})
         await expect(decoration).toBeVisible({
           timeout: 15_000,
         })
-        await page.waitForIdle()
         await expect(decoration).toHaveText(/Self Time/)
-        await page.waitForIdle()
       } catch (error) {
         throw new VError(error, `Failed to take performance profile`)
       }


### PR DESCRIPTION
Investigates the debug-javascript-performance-profile e2e failure where the CPU profile CodeLens never appears. The diagnostic workflow runs the exact skipped scenario in 20 isolated attempts.