### PR TITLE
fix: stabilize cross-file rename e2e

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,52 @@ on:
       - main
 
 jobs:
+  diagnose-editor-cross-file-rename:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        attempt: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+      - name: Compute node modules cache key
+        id: nodeModulesCacheKey
+        run: echo "value=$(node scripts/computeNodeModulesCacheKey.js)" >> $GITHUB_OUTPUT
+        shell: bash
+      - uses: actions/cache@v6
+        id: npm-cache
+        with:
+          path: |
+            **/node_modules
+            **/.vscode-test
+            **/.vscode-insiders-versions
+            **/.vscode-user-data-dir
+            **/.vscode-ffmpeg
+            **/.vscode-resolve-source-map-cache
+          key: ${{ runner.os }}-cacheNodeModules-${{ steps.nodeModulesCacheKey.outputs.value }}
+      - name: npm ci
+        run: npm ci --ignore-scripts && npm run postinstall
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+      - run: npm run build
+      - name: Run editor-cross-file-rename diagnostic attempt ${{ matrix.attempt }}
+        uses: coactions/setup-xvfb@v1
+        with:
+          run: node packages/cli/bin/test.js --cwd packages/e2e --check-leaks --measure-after --measure detached-dom-nodes-with-stack-traces --restart-between --run-skipped-tests-anyway --only '^editor-cross-file-rename\.ts$' --workers 1
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: editor-cross-file-rename-${{ matrix.attempt }}
+          path: |
+            ./.vscode-memory-leak-finder-results
+            ./.vscode-videos
+          include-hidden-files: true
+          if-no-files-found: ignore
+
   pr:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run editor-cross-file-rename diagnostic attempt ${{ matrix.attempt }}
         uses: coactions/setup-xvfb@v1
         with:
-          run: node packages/cli/bin/test.js --cwd packages/e2e --check-leaks --measure-after --measure detached-dom-nodes-with-stack-traces --restart-between --run-skipped-tests-anyway --only '^editor-cross-file-rename\.ts$' --workers 1
+          run: node packages/cli/bin/test.js --cwd packages/e2e --check-leaks --measure-after --measure detached-dom-nodes-with-stack-traces --restart-between --run-skipped-tests-anyway --only ^editor-cross-file-rename.ts --workers 1
       - uses: actions/upload-artifact@v7
         if: always()
         with:

--- a/packages/page-object/src/parts/Editor/Editor.ts
+++ b/packages/page-object/src/parts/Editor/Editor.ts
@@ -942,11 +942,14 @@ export const create = ({ electronApp, expect, ideVersion, page, platform, VError
         const quickPick = QuickPick.create({ electronApp, expect, ideVersion, page, platform, VError })
         await quickPick.executeCommand(WellKnownCommands.RenameSymbol)
         const renameInput = page.locator('.rename-input')
-        await expect(renameInput).toBeVisible()
+        await expect(renameInput).toBeVisible({
+          timeout: 10_000,
+        })
         await expect(renameInput).toBeFocused()
         await renameInput.type(newText)
         await page.waitForIdle()
         await page.keyboard.press('Enter')
+        await expect(renameInput).toBeHidden()
       } catch (error) {
         throw new VError(error, `Failed to rename text ${newText}`)
       }


### PR DESCRIPTION
Stabilizes the flaky editor-cross-file-rename e2e failure where the rename input did not appear within the injected framework's implicit 2-second UI wait. The rename helper now gives the asynchronous language-provider response an explicit 10-second window and verifies the widget closes after acceptance. The draft PR also runs the exact leak-measure scenario in 20 isolated attempts.