### PR TITLE
test: investigate source definition not found e2e failure

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,61 @@ on:
       - main
 
 jobs:
+  diagnose-editor-go-to-source-definition-not-found:
+    name: Source definition not found (attempt ${{ matrix.attempt }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        attempt: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+      - name: Compute node modules cache key
+        id: nodeModulesCacheKey
+        run: echo "value=$(node scripts/computeNodeModulesCacheKey.js)" >> $GITHUB_OUTPUT
+        shell: bash
+      - uses: actions/cache@v6
+        id: npm-cache
+        with:
+          path: |
+            **/node_modules
+            **/.vscode-test
+            **/.vscode-user-data-dir
+            **/.vscode-ffmpeg
+            **/.vscode-resolve-source-map-cache
+          key: ${{ runner.os }}-cacheNodeModules-${{ steps.nodeModulesCacheKey.outputs.value }}
+      - name: npm ci
+        run: npm ci --ignore-scripts && npm run postinstall
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+      - run: npm run build
+      - name: Run targeted diagnostic
+        uses: coactions/setup-xvfb@v1
+        with:
+          run: >-
+            node packages/cli/bin/test.js
+            --cwd packages/e2e
+            --check-leaks
+            --measure-after
+            --measure detached-dom-nodes-with-stack-traces
+            --restart-between
+            --run-skipped-tests-anyway
+            --only ^editor-go-to-source-definition-not-found.ts
+            --workers 1
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: editor-go-to-source-definition-not-found-${{ matrix.attempt }}
+          path: |
+            ./.vscode-memory-leak-finder-results
+            ./.vscode-videos
+          include-hidden-files: true
+          if-no-files-found: ignore
+
   pr:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/packages/page-object/src/parts/Editor/Editor.ts
+++ b/packages/page-object/src/parts/Editor/Editor.ts
@@ -543,7 +543,7 @@ export const create = ({ electronApp, expect, ideVersion, page, platform, VError
         if (hasDefinition) {
           // TODO
         } else {
-          const notification = page.locator('[role="dialog"][aria-label^="Error: No source definitions found."]')
+          const notification = page.locator('.notifications-toasts [aria-label^="Error: No source definitions found."]')
           await expect(notification).toBeVisible()
         }
       } catch (error) {


### PR DESCRIPTION
Investigates the failing `editor-go-to-source-definition-not-found` e2e test with 20 isolated attempts.

The assertion now targets the stable active notification toast instead of depending on VS Code exposing the notification with `role="dialog"`.