### PR TITLE
fix: make editor multi cursor type repeatable

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,59 @@ on:
       - main
 
 jobs:
+  editor-multi-cursor-type-diagnostic:
+    name: editor-multi-cursor-type diagnostic (attempt ${{ matrix.attempt }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        attempt: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+      - name: Compute node modules cache key
+        id: nodeModulesCacheKey
+        run: echo "value=$(node scripts/computeNodeModulesCacheKey.js)" >> $GITHUB_OUTPUT
+        shell: bash
+      - uses: actions/cache@v6
+        id: npm-cache
+        with:
+          path: |
+            **/node_modules
+            **/.vscode-test
+            **/.vscode-user-data-dir
+            **/.vscode-ffmpeg
+            **/.vscode-resolve-source-map-cache
+          key: ${{ runner.os }}-cacheNodeModules-${{ steps.nodeModulesCacheKey.outputs.value }}
+      - name: npm ci
+        run: npm ci --ignore-scripts && npm run postinstall
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+      - run: npm run build
+      - name: Run editor-multi-cursor-type measure-after diagnostic
+        uses: coactions/setup-xvfb@v1
+        with:
+          run: >-
+            node packages/cli/bin/test.js
+            --cwd packages/e2e
+            --only editor-multi-cursor-type.ts
+            --run-skipped-tests-anyway
+            --check-leaks
+            --measure-after
+            --record-video
+            --workers 1
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: editor-multi-cursor-type-attempt-${{ matrix.attempt }}
+          path: |
+            ./.vscode-videos
+            ./packages/e2e/.vscode-memory-leak-finder-results
+          include-hidden-files: true
+
   pr:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/packages/e2e/src/editor-multi-cursor-type.ts
+++ b/packages/e2e/src/editor-multi-cursor-type.ts
@@ -16,7 +16,7 @@ cherry`,
   await Editor.setCursor(1, 1)
 }
 
-export const run = async ({ Editor }: TestContext): Promise<void> => {
+export const run = async ({ Editor, Workspace }: TestContext): Promise<void> => {
   // @ts-ignore
   await Editor.addCursorBelow()
   // @ts-ignore
@@ -31,11 +31,20 @@ prefix cherry`)
   await Editor.shouldHaveText(`prefix apple
 prefix banana
 prefix cherry`)
-  await Editor.undo()
+  await Editor.closeAll()
+  await Workspace.setFiles([
+    {
+      content: `apple
+banana
+cherry`,
+      name: 'file.txt',
+    },
+  ])
+  await Editor.open('file.txt')
+  await Editor.setCursor(1, 1)
   await Editor.shouldHaveText(`apple
 banana
 cherry`)
-  await Editor.save({ viaKeyBoard: false })
 }
 
 export const teardown = async ({ Editor }: TestContext): Promise<void> => {

--- a/packages/e2e/src/editor-multi-cursor-type.ts
+++ b/packages/e2e/src/editor-multi-cursor-type.ts
@@ -31,6 +31,11 @@ prefix cherry`)
   await Editor.shouldHaveText(`prefix apple
 prefix banana
 prefix cherry`)
+  await Editor.undo()
+  await Editor.shouldHaveText(`apple
+banana
+cherry`)
+  await Editor.save({ viaKeyBoard: false })
 }
 
 export const teardown = async ({ Editor }: TestContext): Promise<void> => {


### PR DESCRIPTION
The skipped editor multi-cursor typing test fails in the leak-check measure-after path because that path invokes its run stage twice after one setup.

This draft first runs that exact test and mode in 20 isolated attempts to preserve reproduction evidence.