### PR TITLE
test: investigate flaky editor surround with function

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run exact e2e test
         uses: coactions/setup-xvfb@v1
         with:
-          run: node packages/cli/bin/test.js --cwd packages/e2e --record-video --only editor-surround-with-function.ts --workers 1
+          run: node packages/cli/bin/test.js --cwd packages/e2e --record-video --only editor-surround-with-function.ts --run-skipped-tests-anyway --workers 1
       - uses: actions/upload-artifact@v7
         if: always()
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,49 @@ on:
       - main
 
 jobs:
+  diagnostic-editor-surround-with-function:
+    name: diagnostic editor-surround-with-function (${{ matrix.attempt }}/20)
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        attempt: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+      - name: Compute node modules cache key
+        id: nodeModulesCacheKey
+        run: echo "value=$(node scripts/computeNodeModulesCacheKey.js)" >> $GITHUB_OUTPUT
+        shell: bash
+      - uses: actions/cache@v6
+        id: npm-cache
+        with:
+          path: |
+            **/node_modules
+            **/.vscode-test
+            **/.vscode-user-data-dir
+            **/.vscode-ffmpeg
+            **/.vscode-resolve-source-map-cache
+          key: ${{ runner.os }}-cacheNodeModules-${{ steps.nodeModulesCacheKey.outputs.value }}
+      - name: npm ci
+        run: npm ci --ignore-scripts && npm run postinstall
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+      - run: npm run build
+      - name: Run exact e2e test
+        uses: coactions/setup-xvfb@v1
+        with:
+          run: node packages/cli/bin/test.js --cwd packages/e2e --record-video --only editor-surround-with-function.ts --workers 1
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: editor-surround-with-function-attempt-${{ matrix.attempt }}
+          path: ./.vscode-videos
+          include-hidden-files: true
+
   pr:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/packages/page-object/src/parts/Editor/Editor.ts
+++ b/packages/page-object/src/parts/Editor/Editor.ts
@@ -1112,7 +1112,7 @@ export const create = ({ electronApp, expect, ideVersion, page, platform, VError
         await page.waitForIdle()
         await expect(list).toBeFocused()
         await page.waitForIdle()
-        const actionItem = widget.locator(`.monaco-list-row[aria-label="${actionText}"]`)
+        const actionItem = widget.locator('.monaco-list-row', { hasText: actionText }).first()
         await expect(actionItem).toBeVisible({ timeout: 10_000 })
         await actionItem.click()
         await page.waitForIdle()


### PR DESCRIPTION
Investigates the `editor-surround-with-function.ts` e2e failure with 20 isolated exact-test attempts. Local reproduction showed the action visibly present while the page object relied on an obsolete exact `aria-label`; the branch now selects the visible action row by text.