### PR TITLE
test: reproduce semantic tokens flake

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,52 @@ on:
       - main
 
 jobs:
+  diagnose-editor-toggle-semantic-tokens:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        attempt: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+      - name: Compute node modules cache key
+        id: nodeModulesCacheKey
+        run: echo "value=$(node scripts/computeNodeModulesCacheKey.js)" >> $GITHUB_OUTPUT
+        shell: bash
+      - uses: actions/cache@v6
+        id: npm-cache
+        with:
+          path: |
+            **/node_modules
+            **/.vscode-test
+            **/.vscode-insiders-versions
+            **/.vscode-user-data-dir
+            **/.vscode-ffmpeg
+            **/.vscode-resolve-source-map-cache
+          key: ${{ runner.os }}-cacheNodeModules-${{ steps.nodeModulesCacheKey.outputs.value }}
+      - name: npm ci
+        run: npm ci --ignore-scripts && npm run postinstall
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+      - run: npm run build
+      - name: Run editor-toggle-semantic-tokens diagnostic attempt ${{ matrix.attempt }}
+        uses: coactions/setup-xvfb@v1
+        with:
+          run: node packages/cli/bin/test.js --cwd packages/e2e --check-leaks --measure-after --measure detached-dom-nodes-with-stack-traces --restart-between --run-skipped-tests-anyway --only ^editor-toggle-semantic-tokens.ts --workers 1
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: editor-toggle-semantic-tokens-${{ matrix.attempt }}
+          path: |
+            ./.vscode-memory-leak-finder-results
+            ./.vscode-videos
+          include-hidden-files: true
+          if-no-files-found: ignore
+
   pr:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/packages/e2e/src/editor-toggle-semantic-tokens.ts
+++ b/packages/e2e/src/editor-toggle-semantic-tokens.ts
@@ -49,7 +49,7 @@ export const run = async ({ Editor, SettingsEditor }: TestContext): Promise<void
   await Editor.click('myFunction')
   await Editor.inspectTokens()
   await Editor.shouldHaveInspectedToken('myFunction10 chars')
-  await Editor.shouldNotHaveSemanticToken('class')
+  await Editor.shouldNotHaveSemanticToken('function')
   await Editor.closeInspectedTokens()
   await SettingsEditor.select({
     name: 'editor.semanticHighlighting.enabled',

--- a/packages/page-object/src/parts/Editor/Editor.ts
+++ b/packages/page-object/src/parts/Editor/Editor.ts
@@ -1623,14 +1623,7 @@ export const create = ({ electronApp, expect, ideVersion, page, platform, VError
         await page.waitForIdle()
         const inspectWidget = page.locator('.token-inspect-widget')
         await expect(inspectWidget).toBeVisible()
-        await page.waitForIdle()
-        const widgetText = await inspectWidget.textContent()
-        if (widgetText) {
-          const hasSemanticTokenType = widgetText.toLowerCase().includes('semantic token type')
-          if (hasSemanticTokenType) {
-            throw new Error(`Semantic token information found but should not be present. Widget text: ${widgetText}`)
-          }
-        }
+        await expect(inspectWidget).toHaveText(/^(?!.*semantic token type)[\s\S]*$/i)
       } catch (error) {
         throw new VError(error, `Failed to verify semantic token ${type} is not present`)
       }


### PR DESCRIPTION
Investigates the intermittent editor semantic-token toggle failure.

The token inspector was sampled once while semantic highlighting updates asynchronously. The assertion now waits for semantic-token information to disappear, and this draft runs the exact skipped e2e scenario in 20 isolated, serialized attempts.