### PR TITLE
fix: stabilize explorer find in folder e2e test

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,61 @@ on:
       - main
 
 jobs:
+  diagnose-explorer-find-in-folder:
+    name: explorer-find-in-folder diagnostic (attempt ${{ matrix.attempt }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        attempt: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+      - name: Compute node modules cache key
+        id: nodeModulesCacheKey
+        run: echo "value=$(node scripts/computeNodeModulesCacheKey.js)" >> $GITHUB_OUTPUT
+        shell: bash
+      - uses: actions/cache@v6
+        id: npm-cache
+        with:
+          path: |
+            **/node_modules
+            **/.vscode-test
+            **/.vscode-user-data-dir
+            **/.vscode-ffmpeg
+            **/.vscode-resolve-source-map-cache
+          key: ${{ runner.os }}-cacheNodeModules-${{ steps.nodeModulesCacheKey.outputs.value }}
+      - name: npm ci
+        run: npm ci --ignore-scripts && npm run postinstall
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+      - run: npm run build
+      - name: Run explorer-find-in-folder diagnostic
+        uses: coactions/setup-xvfb@v1
+        with:
+          run: >-
+            node packages/cli/bin/test.js
+            --cwd packages/e2e
+            --check-leaks
+            --measure-after
+            --measure detached-dom-nodes-with-stack-traces
+            --restart-between
+            --run-skipped-tests-anyway
+            --only ^explorer-find-in-folder.ts
+            --workers 1
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: explorer-find-in-folder-${{ matrix.attempt }}
+          path: |
+            ./.vscode-memory-leak-finder-results
+            ./.vscode-videos
+          include-hidden-files: true
+          if-no-files-found: ignore
+
   pr:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/packages/e2e/src/explorer-find-in-folder.ts
+++ b/packages/e2e/src/explorer-find-in-folder.ts
@@ -13,6 +13,9 @@ export const setup = async ({ Editor, Explorer, Workspace }: TestContext): Promi
       name: 'other-file.txt',
     },
   ])
+  await Workspace.updateWorkspaceSettings({
+    'search.mode': 'view',
+  })
   await Editor.closeAll()
   await Explorer.focus()
   await Explorer.shouldHaveItem('folder')


### PR DESCRIPTION
Investigates and stabilizes the failing `explorer-find-in-folder.ts` e2e test.

The test now pins `search.mode` to `view`, matching its `.search-view` assertion. The diagnostic job runs the exact skipped test 20 times in isolation.