### PR TITLE
fix: investigate flaky explorer fs move file

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,69 @@ on:
       - main
 
 jobs:
+  flaky-explorer-fs-move-file:
+    name: explorer-fs-move-file (attempt ${{ matrix.attempt }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        attempt:
+          - 1
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          - 11
+          - 12
+          - 13
+          - 14
+          - 15
+          - 16
+          - 17
+          - 18
+          - 19
+          - 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+      - name: Compute node modules cache key
+        id: nodeModulesCacheKey
+        run: echo "value=$(node scripts/computeNodeModulesCacheKey.js)" >> $GITHUB_OUTPUT
+        shell: bash
+      - uses: actions/cache@v6
+        id: npm-cache
+        with:
+          path: |
+            **/node_modules
+            **/.vscode-test
+            **/.vscode-user-data-dir
+            **/.vscode-ffmpeg
+            **/.vscode-resolve-source-map-cache
+          key: ${{ runner.os }}-cacheNodeModules-${{ steps.nodeModulesCacheKey.outputs.value }}
+      - name: npm ci
+        run: npm ci --ignore-scripts && npm run postinstall
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+      - run: npm run build
+      - name: Run explorer-fs-move-file
+        uses: coactions/setup-xvfb@v1
+        with:
+          run: node packages/cli/bin/test.js --cwd packages/e2e --only explorer-fs-move-file.ts --workers 1 --record-video --run-skipped-tests-anyway
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: explorer-fs-move-file-attempt-${{ matrix.attempt }}
+          path: ./.vscode-videos
+          include-hidden-files: true
+
   pr:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,6 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      max-parallel: 1
       matrix:
         attempt:
           - 1

--- a/packages/e2e/src/explorer-fs-move-file.ts
+++ b/packages/e2e/src/explorer-fs-move-file.ts
@@ -56,6 +56,7 @@ export const run = async ({ Explorer, Workspace }: TestContext): Promise<void> =
   await Explorer.refresh()
 
   // Verify file moved from source to destination
+  await Explorer.collapse('destination-folder')
   await Explorer.expand('source-folder')
   await Explorer.not.toHaveItem('file-in-source.txt')
   await Explorer.shouldHaveItem('nested-file.txt') // Other file should remain

--- a/packages/e2e/src/explorer-fs-move-file.ts
+++ b/packages/e2e/src/explorer-fs-move-file.ts
@@ -75,7 +75,6 @@ export const run = async ({ Explorer, Workspace }: TestContext): Promise<void> =
   await Explorer.refresh()
 
   // Verify folder structure change
-  await Explorer.collapse('source-folder')
   await Explorer.not.toHaveItem('source-folder')
 
   await Explorer.expand('another-folder')


### PR DESCRIPTION
Investigates the flaky `explorer-fs-move-file.ts` scenario by running it 20 isolated times in CI to collect evidence.