### PR TITLE
fix: investigate flaky explorer rename file

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,60 @@ on:
       - main
 
 jobs:
+  diagnose-explorer-rename-file:
+    name: explorer-rename-file diagnostic (attempt ${{ matrix.attempt }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        attempt: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+      - name: Compute node modules cache key
+        id: nodeModulesCacheKey
+        run: echo "value=$(node scripts/computeNodeModulesCacheKey.js)" >> $GITHUB_OUTPUT
+        shell: bash
+      - uses: actions/cache@v6
+        id: npm-cache
+        with:
+          path: |
+            **/node_modules
+            **/.vscode-test
+            **/.vscode-user-data-dir
+            **/.vscode-ffmpeg
+            **/.vscode-resolve-source-map-cache
+          key: ${{ runner.os }}-cacheNodeModules-${{ steps.nodeModulesCacheKey.outputs.value }}
+      - name: npm ci
+        run: npm ci --ignore-scripts && npm run postinstall
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+      - run: npm run build
+      - name: Run explorer-rename-file diagnostic
+        uses: coactions/setup-xvfb@v1
+        with:
+          run: >-
+            node packages/cli/bin/test.js
+            --cwd packages/e2e
+            --check-leaks
+            --measure-after
+            --run-skipped-tests-anyway
+            --only ^explorer-rename-file.ts
+            --workers 1
+            --record-video
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: explorer-rename-file-${{ matrix.attempt }}
+          path: |
+            ./.vscode-memory-leak-finder-results
+            ./.vscode-videos
+          include-hidden-files: true
+          if-no-files-found: ignore
+
   pr:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/packages/page-object/src/parts/ContextMenu/ContextMenu.ts
+++ b/packages/page-object/src/parts/ContextMenu/ContextMenu.ts
@@ -50,22 +50,9 @@ export const create = ({ expect, page, VError }: CreateParams) => {
         await page.waitForIdle()
         const contextMenu = page.locator('.context-view.monaco-menu-container .actions-container')
         await expect(contextMenu).toBeHidden()
-        let tries = 0
-        const maxTries = 11
-        while (true) {
-          await page.waitForIdle()
-          await locator.click({
-            button: 'right',
-          })
-          const isVisible = await contextMenu.isVisible()
-          if (isVisible) {
-            break
-          }
-          await page.waitForIdle()
-          if (tries++ === maxTries) {
-            throw new Error(`failed to open`)
-          }
-        }
+        await locator.click({
+          button: 'right',
+        })
         await expect(contextMenu).toBeVisible()
         await expect(contextMenu).toBeFocused()
       } catch (error) {


### PR DESCRIPTION
Investigates the flaky `explorer-rename-file.ts` failure when opening the context menu for the second rename.

Runs the exact scenario in 20 isolated CI attempts to collect evidence.