### PR TITLE
fix: stabilize extension detail disable e2e

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,56 @@ on:
       - main
 
 jobs:
+  diagnose-extension-detail-view-disable-extension:
+    name: extension-detail-view-disable-extension (attempt ${{ matrix.attempt }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        attempt: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+      - name: Compute node modules cache key
+        id: nodeModulesCacheKey
+        run: echo "value=$(node scripts/computeNodeModulesCacheKey.js)" >> $GITHUB_OUTPUT
+        shell: bash
+      - uses: actions/cache@v6
+        id: npm-cache
+        with:
+          path: |
+            **/node_modules
+            **/.vscode-test
+            **/.vscode-user-data-dir
+            **/.vscode-ffmpeg
+            **/.vscode-resolve-source-map-cache
+          key: ${{ runner.os }}-cacheNodeModules-${{ steps.nodeModulesCacheKey.outputs.value }}
+      - name: npm ci
+        run: npm ci --ignore-scripts && npm run postinstall
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+      - run: npm run build
+      - name: Run exact e2e test
+        uses: coactions/setup-xvfb@v1
+        with:
+          run: >-
+            node packages/cli/bin/test.js
+            --cwd packages/e2e
+            --only ^extension-detail-view-disable-extension.ts
+            --run-skipped-tests-anyway
+            --record-video
+            --workers 1
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: extension-detail-view-disable-extension-attempt-${{ matrix.attempt }}
+          path: ./.vscode-videos
+          include-hidden-files: true
+          if-no-files-found: ignore
+
   pr:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/packages/page-object/src/parts/ExtensionsDetailView/ExtensionsDetailView.ts
+++ b/packages/page-object/src/parts/ExtensionsDetailView/ExtensionsDetailView.ts
@@ -79,7 +79,7 @@ export const create = ({ expect, page, VError }: CreateParams) => {
         await page.waitForIdle()
         await tab.click()
         await page.waitForIdle()
-        await expect(tab).toHaveAttribute('aria-checked', 'true')
+        await expect(tab).toHaveAttribute('aria-pressed', 'true')
         await page.waitForIdle()
         if (options && options.webView) {
           const webView = page.locator('.webview')
@@ -139,7 +139,7 @@ export const create = ({ expect, page, VError }: CreateParams) => {
           hasText: text,
         })
         await expect(tab).toBeVisible()
-        await expect(tab).toHaveAttribute('aria-checked', 'true')
+        await expect(tab).toHaveAttribute('aria-pressed', 'true')
       } catch (error) {
         throw new VError(error, `Failed to verify extension detail tab ${text}`)
       }


### PR DESCRIPTION
Investigates the failing extension-detail-view-disable-extension e2e test. The diagnostic workflow runs the exact test 20 times to collect evidence.