### PR TITLE
fix: stabilize notification show e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
           - name: worker-count
             args: --measure worker-count
           - name: detached-dom-nodes-with-stack-traces
-            args: --measure detached-dom-nodes-with-stack-traces --runs 37 --restart-between --run-skipped-tests-anyway
+            args: --measure detached-dom-nodes-with-stack-traces --runs 37 --restart-between --run-skipped-tests-anyway --enable-extensions
           - name: file-descriptor-count
             args: --measure file-descriptor-count --runs 37 --restart-between --run-skipped-tests-anyway
           - name: file-descriptors

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Run notification-show diagnostic attempt ${{ matrix.attempt }}
         uses: coactions/setup-xvfb@v1
         with:
-          run: node packages/cli/bin/test.js --cwd packages/e2e --check-leaks --measure-after --measure detached-dom-nodes-with-stack-traces --restart-between --run-skipped-tests-anyway --only ^notification-show.ts --workers 1 --record-video
+          run: node packages/cli/bin/test.js --cwd packages/e2e --check-leaks --measure-after --measure detached-dom-nodes-with-stack-traces --restart-between --run-skipped-tests-anyway --enable-extensions --only ^notification-show.ts --workers 1 --record-video
       - uses: actions/upload-artifact@v7
         if: always()
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,53 @@ on:
       - main
 
 jobs:
+  diagnose-notification-show:
+    name: notification-show (attempt ${{ matrix.attempt }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        attempt: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+      - name: Compute node modules cache key
+        id: nodeModulesCacheKey
+        run: echo "value=$(node scripts/computeNodeModulesCacheKey.js)" >> $GITHUB_OUTPUT
+        shell: bash
+      - uses: actions/cache@v6
+        id: npm-cache
+        with:
+          path: |
+            **/node_modules
+            **/.vscode-test
+            **/.vscode-insiders-versions
+            **/.vscode-user-data-dir
+            **/.vscode-ffmpeg
+            **/.vscode-resolve-source-map-cache
+          key: ${{ runner.os }}-cacheNodeModules-${{ steps.nodeModulesCacheKey.outputs.value }}
+      - name: npm ci
+        run: npm ci --ignore-scripts && npm run postinstall
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+      - run: npm run build
+      - name: Run notification-show diagnostic attempt ${{ matrix.attempt }}
+        uses: coactions/setup-xvfb@v1
+        with:
+          run: node packages/cli/bin/test.js --cwd packages/e2e --check-leaks --measure-after --measure detached-dom-nodes-with-stack-traces --restart-between --run-skipped-tests-anyway --only ^notification-show.ts --workers 1 --record-video
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: notification-show-${{ matrix.attempt }}
+          path: |
+            ./.vscode-memory-leak-finder-results
+            ./.vscode-videos
+          include-hidden-files: true
+          if-no-files-found: ignore
+
   pr:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/packages/e2e/src/notification-show.ts
+++ b/packages/e2e/src/notification-show.ts
@@ -8,6 +8,7 @@ export const setup = async ({ Extensions }: TestContext) => {
 }
 
 export const run = async ({ Notification, QuickPick }: TestContext): Promise<void> => {
+  await QuickPick.waitForCommand('Hello World')
   await QuickPick.showCommands()
   await QuickPick.type('Hello world')
   await QuickPick.select('Hello World')

--- a/packages/e2e/src/notification-show.ts
+++ b/packages/e2e/src/notification-show.ts
@@ -8,7 +8,6 @@ export const setup = async ({ Extensions }: TestContext) => {
 }
 
 export const run = async ({ Notification, QuickPick }: TestContext): Promise<void> => {
-  await QuickPick.waitForCommand('Hello World')
   await QuickPick.showCommands()
   await QuickPick.type('Hello world')
   await QuickPick.select('Hello World')


### PR DESCRIPTION
Investigates the flaky `notification-show.ts` failure in the detached-DOM measurement job. The recorded failure shows VS Code reporting that installed extensions are temporarily disabled, so the fixture cannot contribute `Hello World`. The fix enables extensions for that measurement; the diagnostic job runs the exact test 20 times and uploads per-attempt results and video.