### PR TITLE
fix: stabilize notification storm e2e test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
           - name: worker-count
             args: --measure worker-count
           - name: detached-dom-nodes-with-stack-traces
-            args: --measure detached-dom-nodes-with-stack-traces --runs 37 --restart-between --run-skipped-tests-anyway
+            args: --measure detached-dom-nodes-with-stack-traces --runs 37 --restart-between --run-skipped-tests-anyway --enable-extensions
           - name: file-descriptor-count
             args: --measure file-descriptor-count --runs 37 --restart-between --run-skipped-tests-anyway
           - name: file-descriptors

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,61 @@ on:
       - main
 
 jobs:
+  diagnose-notification-storm:
+    name: notification-storm (attempt ${{ matrix.attempt }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        attempt: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+      - name: Compute node modules cache key
+        id: nodeModulesCacheKey
+        run: echo "value=$(node scripts/computeNodeModulesCacheKey.js)" >> $GITHUB_OUTPUT
+        shell: bash
+      - uses: actions/cache@v6
+        id: npm-cache
+        with:
+          path: |
+            **/node_modules
+            **/.vscode-test
+            **/.vscode-user-data-dir
+            **/.vscode-ffmpeg
+            **/.vscode-resolve-source-map-cache
+          key: ${{ runner.os }}-cacheNodeModules-${{ steps.nodeModulesCacheKey.outputs.value }}
+      - name: npm ci
+        run: npm ci --ignore-scripts && npm run postinstall
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+      - run: npm run build
+      - name: Run exact notification-storm test
+        uses: coactions/setup-xvfb@v1
+        with:
+          run: >-
+            node packages/cli/bin/test.js
+            --cwd packages/e2e
+            --check-leaks
+            --measure detached-dom-nodes-with-stack-traces
+            --restart-between
+            --run-skipped-tests-anyway
+            --only ^notification-storm.ts
+            --workers 1
+            --record-video
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: notification-storm-attempt-${{ matrix.attempt }}
+          path: |
+            ./.vscode-memory-leak-finder-results
+            ./.vscode-videos
+          include-hidden-files: true
+          if-no-files-found: ignore
+
   pr:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -48,6 +48,7 @@ jobs:
             --measure detached-dom-nodes-with-stack-traces
             --restart-between
             --run-skipped-tests-anyway
+            --enable-extensions
             --only ^notification-storm.ts
             --workers 1
             --record-video


### PR DESCRIPTION
Investigates and fixes the notification-storm e2e failure from the detached DOM measurement job.

The fixture command could not register because the measure force-ran extension-backed tests while VS Code was launched with extensions disabled. The draft PR enables extensions for that measure and runs the exact test in 20 isolated attempts.