### PR TITLE
fix: resolve tracked allocation source maps

### DIFF
--- a/packages/memory-leak-finder/src/parts/CompareTrackedAllocationTimeline/CompareTrackedAllocationTimeline.ts
+++ b/packages/memory-leak-finder/src/parts/CompareTrackedAllocationTimeline/CompareTrackedAllocationTimeline.ts
@@ -10,6 +10,7 @@ export interface TrackedAllocationTimelineResultEntry {
   readonly originalLine: number | null
   readonly originalLocation: string | null
   readonly originalSource: string | null
+  readonly originalType: string
   readonly type: string
 }
 
@@ -46,6 +47,7 @@ export const compareTrackedAllocationTimeline = async (
         originalLine: resolved.originalLine,
         originalLocation: resolved.originalLocation,
         originalSource: resolved.originalSource,
+        originalType: resolved.originalName || allocation.type,
         type: allocation.type,
       }
     })

--- a/packages/memory-leak-finder/src/parts/CompareTrackedAllocations/CompareTrackedAllocations.ts
+++ b/packages/memory-leak-finder/src/parts/CompareTrackedAllocations/CompareTrackedAllocations.ts
@@ -12,6 +12,7 @@ export interface TrackedAllocationResult {
   readonly originalLine: number | null
   readonly originalLocation: string | null
   readonly originalSource: string | null
+  readonly originalType: string
   readonly type: string
 }
 
@@ -70,6 +71,7 @@ export const compareTrackedAllocations = async (
       originalLine: resolved.originalLine,
       originalLocation: resolved.originalLocation,
       originalSource: resolved.originalSource,
+      originalType: resolved.originalName || afterEntry.type,
       type: afterEntry.type,
     })
   }

--- a/packages/memory-leak-finder/src/parts/GetCleanPositionsMap/GetCleanPositionsMap.ts
+++ b/packages/memory-leak-finder/src/parts/GetCleanPositionsMap/GetCleanPositionsMap.ts
@@ -1,7 +1,7 @@
 import type { Dynamic } from '../Types/Types.ts'
 import * as LaunchSourceMapWorker from '../LaunchSourceMapWorker/LaunchSourceMapWorker.ts'
-export const getCleanPositionsMap = async (sourceMapUrlMap: Dynamic, classNames: Dynamic) => {
+export const getCleanPositionsMap = async (sourceMapUrlMap: Dynamic, classNames: Dynamic, constructorNames = false) => {
   await using rpc = await LaunchSourceMapWorker.launchSourceMapCoordinator()
-  const response = await rpc.invoke('SourceMap.getCleanPositionsMap', sourceMapUrlMap, classNames)
+  const response = await rpc.invoke('SourceMap.getCleanPositionsMap', sourceMapUrlMap, classNames, constructorNames)
   return response
 }

--- a/packages/memory-leak-finder/src/parts/ResolveTrackedLocationSourceMaps/ResolveTrackedLocationSourceMaps.ts
+++ b/packages/memory-leak-finder/src/parts/ResolveTrackedLocationSourceMaps/ResolveTrackedLocationSourceMaps.ts
@@ -174,7 +174,7 @@ export const resolveTrackedLocationSourceMaps = async (
     return result
   }
 
-  const cleanPositionMap = await GetCleanPositionsMap.getCleanPositionsMap(sourceMapUrlToPositions, true)
+  const cleanPositionMap = await GetCleanPositionsMap.getCleanPositionsMap(sourceMapUrlToPositions, false, true)
   const offsetMap: Record<string, number> = Object.create(null)
   for (const pointer of pointers) {
     const positions = cleanPositionMap[pointer.sourceMapUrl] || []

--- a/packages/memory-leak-finder/src/parts/ResolveTrackedLocationSourceMaps/ResolveTrackedLocationSourceMaps.ts
+++ b/packages/memory-leak-finder/src/parts/ResolveTrackedLocationSourceMaps/ResolveTrackedLocationSourceMaps.ts
@@ -42,7 +42,12 @@ const parseLocation = (
 
 const normalizeUrl = (url: string): string => {
   try {
-    const path = url.startsWith('file://') ? fileURLToPath(url) : url
+    const vscodeFilePrefix = 'vscode-file://vscode-app'
+    const path = url.startsWith(vscodeFilePrefix)
+      ? decodeURIComponent(url.slice(vscodeFilePrefix.length))
+      : url.startsWith('file://')
+        ? fileURLToPath(url)
+        : url
     if (isAbsolute(path)) {
       return normalize(path)
     }
@@ -50,6 +55,24 @@ const normalizeUrl = (url: string): string => {
   } catch {
     return url
   }
+}
+
+const getRuntimeRelativePath = (path: string): string => {
+  const match = path.match(/(?:^|[\\/])resources[\\/]app[\\/](.*)$/)
+  return match?.[1]?.replaceAll('\\', '/') || ''
+}
+
+const isMatchingScriptUrl = (scriptUrl: string, targetUrl: string): boolean => {
+  if (scriptUrl === targetUrl) {
+    return true
+  }
+  const normalizedScriptUrl = normalizeUrl(scriptUrl)
+  const normalizedTargetUrl = normalizeUrl(targetUrl)
+  if (normalizedScriptUrl === normalizedTargetUrl) {
+    return true
+  }
+  const scriptRuntimeRelativePath = getRuntimeRelativePath(normalizedScriptUrl)
+  return Boolean(scriptRuntimeRelativePath && scriptRuntimeRelativePath === getRuntimeRelativePath(normalizedTargetUrl))
 }
 
 const isRelativeSourceMap = (sourceMapUrl: string): boolean => {
@@ -102,13 +125,11 @@ const findScript = (scriptMap: ScriptMap, urlOrScriptId: string): ScriptMapEntry
     return findWorkbenchScript(scriptMap)
   }
 
-  const normalizedTarget = normalizeUrl(urlOrScriptId)
   for (const script of Object.values(scriptMap)) {
     if (!script.url) {
       continue
     }
-    const normalizedScriptUrl = normalizeUrl(script.url)
-    if (script.url === urlOrScriptId || normalizedScriptUrl === normalizedTarget) {
+    if (isMatchingScriptUrl(script.url, urlOrScriptId)) {
       return script
     }
   }

--- a/packages/memory-leak-finder/test/CompareTrackedAllocations.test.ts
+++ b/packages/memory-leak-finder/test/CompareTrackedAllocations.test.ts
@@ -34,6 +34,7 @@ test('compareTrackedAllocations returns sorted allocation churn rows', async () 
       originalLine: null,
       originalLocation: null,
       originalSource: null,
+      originalType: 'Object',
       type: 'Object',
     },
     {
@@ -45,6 +46,7 @@ test('compareTrackedAllocations returns sorted allocation churn rows', async () 
       originalLine: null,
       originalLocation: null,
       originalSource: null,
+      originalType: 'Array',
       type: 'Array',
     },
   ])

--- a/packages/memory-leak-finder/test/CompareTrackedAllocationsOriginalType.test.ts
+++ b/packages/memory-leak-finder/test/CompareTrackedAllocationsOriginalType.test.ts
@@ -1,0 +1,39 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/ResolveTrackedLocationSourceMaps/ResolveTrackedLocationSourceMaps.ts', () => ({
+  resolveTrackedLocationSourceMaps: jest.fn(async () => ({
+    '1:2:3': {
+      originalColumn: 8,
+      originalLine: 257,
+      originalLocation: 'src/vs/base/browser/dom.ts:257:8',
+      originalName: 'DomListener',
+      originalSource: 'src/vs/base/browser/dom.ts',
+    },
+  })),
+}))
+
+test('compareTrackedAllocations includes the original constructor type', async () => {
+  const CompareTrackedAllocations = await import('../src/parts/CompareTrackedAllocations/CompareTrackedAllocations.ts')
+  const result = await CompareTrackedAllocations.compareTrackedAllocations(
+    {},
+    {
+      trackedAllocations: {
+        '1:2:3:Eui': {
+          aliveCount: 1,
+          collectedCount: 2,
+          createdCount: 3,
+          location: '1:2:3',
+          type: 'Eui',
+        },
+      },
+    },
+    {} as any,
+  )
+
+  expect(result).toEqual([
+    expect.objectContaining({
+      originalType: 'DomListener',
+      type: 'Eui',
+    }),
+  ])
+})

--- a/packages/memory-leak-finder/test/MeasureTrackedAllocationTimeline.test.ts
+++ b/packages/memory-leak-finder/test/MeasureTrackedAllocationTimeline.test.ts
@@ -124,6 +124,7 @@ test('MeasureTrackedAllocationTimeline.compare enriches timeline rows', async ()
           originalLine: null,
           originalLocation: null,
           originalSource: null,
+          originalType: 'Array',
           type: 'Array',
         },
       ],

--- a/packages/memory-leak-finder/test/ResolveTrackedLocationSourceMaps.test.ts
+++ b/packages/memory-leak-finder/test/ResolveTrackedLocationSourceMaps.test.ts
@@ -38,6 +38,7 @@ test('resolves tracked runtime locations against vscode-file script urls', async
     {
       [sourceMapUrl]: [440, 2784],
     },
+    false,
     true,
   )
   expect(result[location]).toEqual({

--- a/packages/memory-leak-finder/test/ResolveTrackedLocationSourceMaps.test.ts
+++ b/packages/memory-leak-finder/test/ResolveTrackedLocationSourceMaps.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const mockGetCleanPositionsMap = jest.fn<(...args: any[]) => Promise<any>>()
+
+jest.unstable_mockModule('../src/parts/GetCleanPositionsMap/GetCleanPositionsMap.ts', () => ({
+  getCleanPositionsMap: mockGetCleanPositionsMap,
+}))
+
+beforeEach(() => {
+  jest.resetModules()
+  mockGetCleanPositionsMap.mockReset()
+})
+
+test('resolves tracked runtime locations against vscode-file script urls', async () => {
+  const sourceMapUrl = 'https://main.vscode-cdn.net/sourcemaps/commit/core/vs/workbench/workbench.desktop.main.js.map'
+  mockGetCleanPositionsMap.mockResolvedValue({
+    [sourceMapUrl]: [
+      {
+        column: 17,
+        line: 42,
+        name: 'EditorService.openEditor',
+        source: 'src/vs/workbench/services/editor/common/editorService.ts',
+      },
+    ],
+  })
+  const ResolveTrackedLocationSourceMaps = await import('../src/parts/ResolveTrackedLocationSourceMaps/ResolveTrackedLocationSourceMaps.ts')
+  const location = '/tmp/vscode-linux-x64/resources/app/out/vs/workbench/workbench.desktop.main.js:441:2785'
+  const scriptMap = {
+    '123': {
+      sourceMapUrl,
+      url: 'vscode-file://vscode-app/tmp/vscode-linux-x64-modified-tracked-allocations/resources/app/out/vs/workbench/workbench.desktop.main.js',
+    },
+  }
+
+  const result = await ResolveTrackedLocationSourceMaps.resolveTrackedLocationSourceMaps([location], scriptMap)
+
+  expect(mockGetCleanPositionsMap).toHaveBeenCalledWith(
+    {
+      [sourceMapUrl]: [440, 2784],
+    },
+    true,
+  )
+  expect(result[location]).toEqual({
+    originalColumn: 17,
+    originalLine: 42,
+    originalLocation: 'src/vs/workbench/services/editor/common/editorService.ts:42:17',
+    originalName: 'EditorService.openEditor',
+    originalSource: 'src/vs/workbench/services/editor/common/editorService.ts',
+  })
+})

--- a/packages/original-name-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/original-name-worker/src/parts/CommandMap/CommandMap.ts
@@ -1,9 +1,15 @@
 import * as GetOriginalClassName from '../GetOriginalClassName/GetOriginalClassName.ts'
 import * as GetOriginalClassNameFromFile from '../GetOriginalClassNameFromFile/GetOriginalClassNameFromFile.ts'
 import { getOriginalClassNameFromFiles } from '../GetOriginalClassNameFromFiles/GetOriginalClassNameFromFiles.ts'
+import * as GetOriginalConstructorName from '../GetOriginalConstructorName/GetOriginalConstructorName.ts'
+import * as GetOriginalConstructorNameFromFile from '../GetOriginalConstructorNameFromFile/GetOriginalConstructorNameFromFile.ts'
+import { getOriginalConstructorNameFromFiles } from '../GetOriginalConstructorNameFromFiles/GetOriginalConstructorNameFromFiles.ts'
 
 export const commandMap: Record<string, any> = {
   'OriginalName.getOriginalName': GetOriginalClassName.getOriginalClassName,
   'OriginalName.getOriginalNameFromFile': GetOriginalClassNameFromFile.getOriginalClassNameFromFile,
   'OriginalName.getOriginalNameFromFiles': getOriginalClassNameFromFiles,
+  'OriginalName.getOriginalConstructorName': GetOriginalConstructorName.getOriginalConstructorName,
+  'OriginalName.getOriginalConstructorNameFromFile': GetOriginalConstructorNameFromFile.getOriginalConstructorNameFromFile,
+  'OriginalName.getOriginalConstructorNameFromFiles': getOriginalConstructorNameFromFiles,
 }

--- a/packages/original-name-worker/src/parts/GetOriginalConstructorName/GetOriginalConstructorName.ts
+++ b/packages/original-name-worker/src/parts/GetOriginalConstructorName/GetOriginalConstructorName.ts
@@ -1,0 +1,69 @@
+import type { NodePath } from '@babel/traverse'
+import type * as t from '@babel/types'
+import { traverseAst } from '../GetTraverse/GetTraverse.ts'
+import { isLocationInside } from '../IsLocationInside/IsLocationInside.ts'
+import { parseAst } from '../ParseAst/ParseAst.ts'
+
+const getExpressionName = (node: any): string => {
+  if (node?.type === 'Identifier') {
+    return node.name
+  }
+  if (node?.type === 'MemberExpression' || node?.type === 'OptionalMemberExpression') {
+    const objectName = getExpressionName(node.object)
+    const propertyName =
+      node.property?.type === 'Identifier' ? node.property.name : node.property?.type === 'StringLiteral' ? node.property.value : ''
+    return objectName && propertyName ? `${objectName}.${propertyName}` : propertyName
+  }
+  if (node?.type === 'TSInstantiationExpression') {
+    return getExpressionName(node.expression)
+  }
+  return ''
+}
+
+const getLocationSize = (node: t.Node): number => {
+  if (!node.loc) {
+    return Number.POSITIVE_INFINITY
+  }
+  return (node.loc.end.line - node.loc.start.line) * 100_000 + node.loc.end.column - node.loc.start.column
+}
+
+const getConstructorNameFromAst = (ast: t.File, originalLine: number, originalColumn: number): string => {
+  let bestPath: NodePath<t.NewExpression> | undefined
+  traverseAst(ast, {
+    NewExpression(path: NodePath<t.NewExpression>) {
+      if (!isLocationInside(path.node, originalLine, originalColumn)) {
+        return
+      }
+      if (!bestPath || getLocationSize(path.node) <= getLocationSize(bestPath.node)) {
+        bestPath = path
+      }
+    },
+  })
+  return bestPath ? getExpressionName(bestPath.node.callee) : ''
+}
+
+const getConstructorNameFromLine = (sourceContent: string, originalLine: number, originalColumn: number): string => {
+  const line = sourceContent.split('\n')[originalLine] || ''
+  const matches = [...line.matchAll(/\bnew\s+([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)/g)]
+  const closest = matches.toSorted((a, b) => {
+    return Math.abs((a.index || 0) - originalColumn) - Math.abs((b.index || 0) - originalColumn)
+  })[0]
+  return closest?.[1] || ''
+}
+
+export const getOriginalConstructorName = (
+  sourceContent: string,
+  originalLine: number,
+  originalColumn: number,
+  _originalFileName: string,
+): string => {
+  if (!sourceContent) {
+    return ''
+  }
+  try {
+    const ast = parseAst(sourceContent)
+    return getConstructorNameFromAst(ast, originalLine, originalColumn)
+  } catch {
+    return getConstructorNameFromLine(sourceContent, originalLine, originalColumn)
+  }
+}

--- a/packages/original-name-worker/src/parts/GetOriginalConstructorNameFromFile/GetOriginalConstructorNameFromFile.ts
+++ b/packages/original-name-worker/src/parts/GetOriginalConstructorNameFromFile/GetOriginalConstructorNameFromFile.ts
@@ -1,0 +1,21 @@
+import { VError } from '@lvce-editor/verror'
+import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { basename } from 'node:path'
+import * as GetOriginalConstructorName from '../GetOriginalConstructorName/GetOriginalConstructorName.ts'
+
+export const getOriginalConstructorNameFromFile = async (
+  originalCodePath: string,
+  originalLine: number,
+  originalColumn: number,
+): Promise<string> => {
+  try {
+    if (originalLine === null || originalColumn === null || !existsSync(originalCodePath)) {
+      return ''
+    }
+    const originalCode = await readFile(originalCodePath, 'utf8')
+    return GetOriginalConstructorName.getOriginalConstructorName(originalCode, originalLine, originalColumn, basename(originalCodePath))
+  } catch (error) {
+    throw new VError(error, `Failed to compute original constructor name for ${originalCodePath}`)
+  }
+}

--- a/packages/original-name-worker/src/parts/GetOriginalConstructorNameFromFiles/GetOriginalConstructorNameFromFiles.ts
+++ b/packages/original-name-worker/src/parts/GetOriginalConstructorNameFromFiles/GetOriginalConstructorNameFromFiles.ts
@@ -1,0 +1,10 @@
+import { getOriginalConstructorNameFromFile } from '../GetOriginalConstructorNameFromFile/GetOriginalConstructorNameFromFile.ts'
+
+export const getOriginalConstructorNameFromFiles = async (items: readonly any[]): Promise<readonly string[]> => {
+  const mapped: string[] = []
+  for (const item of items) {
+    const resolved = await getOriginalConstructorNameFromFile(item.codePath, item.line, item.column)
+    mapped.push(resolved)
+  }
+  return mapped
+}

--- a/packages/original-name-worker/test/GetOriginalConstructorName.test.ts
+++ b/packages/original-name-worker/test/GetOriginalConstructorName.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@jest/globals'
+import * as GetOriginalConstructorName from '../src/parts/GetOriginalConstructorName/GetOriginalConstructorName.ts'
+
+const getOriginalConstructorName = (sourceContent: string, originalLine: number, originalColumn: number): string => {
+  return GetOriginalConstructorName.getOriginalConstructorName(sourceContent, originalLine, originalColumn, 'test.ts')
+}
+
+test('getOriginalConstructorName - constructor invocation', () => {
+  const sourceContent = `function addDisposableListener() {
+  return new DomListener(node, type, handler)
+}`
+
+  expect(getOriginalConstructorName(sourceContent, 1, 9)).toBe('DomListener')
+})
+
+test('getOriginalConstructorName - nested constructor invocation', () => {
+  const sourceContent = `function allocate() {
+  return new VSBuffer(new Uint8Array(byteLength))
+}`
+
+  expect(getOriginalConstructorName(sourceContent, 1, 9)).toBe('VSBuffer')
+  expect(getOriginalConstructorName(sourceContent, 1, 22)).toBe('Uint8Array')
+})
+
+test('getOriginalConstructorName - member constructor invocation', () => {
+  const sourceContent = `const value = new namespace.Widget()`
+
+  expect(getOriginalConstructorName(sourceContent, 0, 14)).toBe('namespace.Widget')
+})
+
+test('getOriginalConstructorName - non-constructor allocation', () => {
+  const sourceContent = `const values = [new Widget()]`
+
+  expect(getOriginalConstructorName(sourceContent, 0, 15)).toBe('')
+})

--- a/packages/source-map-coordinator/src/parts/GetCleanPositionsMap/GetCleanPositionsMap.ts
+++ b/packages/source-map-coordinator/src/parts/GetCleanPositionsMap/GetCleanPositionsMap.ts
@@ -15,7 +15,11 @@ const getUnresolvedPositions = (positions: readonly number[]): any[] => {
   return new Array(positions.length / 2).fill(undefined)
 }
 
-export const getCleanPositionsMap = async (sourceMapUrlMap: SourceMapUrlMap, classNames: boolean): Promise<CleanPositionMap> => {
+export const getCleanPositionsMap = async (
+  sourceMapUrlMap: SourceMapUrlMap,
+  classNames: boolean,
+  constructorNames = false,
+): Promise<CleanPositionMap> => {
   await using sourceMapWorker = await launchSourceMapWorker()
   const cleanPositionMap: CleanPositionMap = Object.create(null)
   for (const [key, value] of Object.entries(sourceMapUrlMap)) {
@@ -26,7 +30,15 @@ export const getCleanPositionsMap = async (sourceMapUrlMap: SourceMapUrlMap, cla
     try {
       const hash = Hash.hash(key)
       const sourceMap = await LoadSourceMap.loadSourceMap(key, hash)
-      const originalPositions = await sourceMapWorker.invoke('SourceMap.getCleanPositionsMap2', sourceMap, value, classNames, hash, key)
+      const originalPositions = await sourceMapWorker.invoke(
+        'SourceMap.getCleanPositionsMap2',
+        sourceMap,
+        value,
+        classNames,
+        hash,
+        key,
+        constructorNames,
+      )
       const cleanPositions = originalPositions.map(GetCleanPosition.getCleanPosition)
       cleanPositionMap[key] = cleanPositions
     } catch (error) {

--- a/packages/source-map-worker/src/parts/AddOriginalNames/AddOriginalNames.ts
+++ b/packages/source-map-worker/src/parts/AddOriginalNames/AddOriginalNames.ts
@@ -2,14 +2,24 @@ import type { IntermediateItem } from '../IntermediateItem/IntermediateItem.ts'
 import type { OriginalPosition } from '../OriginalPosition/OriginalPosition.ts'
 import * as OriginalNameWorker from '../OriginalNameWorker/OriginalNameWorker.ts'
 
-const getOriginalNames = async (items: readonly IntermediateItem[]): Promise<readonly string[]> => {
+const getOriginalNames = async (items: readonly IntermediateItem[], constructorNames: boolean): Promise<readonly string[]> => {
   await using rpc = await OriginalNameWorker.create()
-  const originalNames = await rpc.invoke('OriginalName.getOriginalNameFromFiles', items)
+  const command = constructorNames ? 'OriginalName.getOriginalConstructorNameFromFiles' : 'OriginalName.getOriginalNameFromFiles'
+  const rpcItems = constructorNames
+    ? items.map((item) => ({
+        ...item,
+        line: item.line === null ? null : item.line - 1,
+      }))
+    : items
+  const originalNames = await rpc.invoke(command, rpcItems)
   return originalNames
 }
 
-export const addOriginalNames = async (intermediateItems: readonly IntermediateItem[]): Promise<readonly OriginalPosition[]> => {
-  const names = await getOriginalNames(intermediateItems)
+export const addOriginalNames = async (
+  intermediateItems: readonly IntermediateItem[],
+  constructorNames = false,
+): Promise<readonly OriginalPosition[]> => {
+  const names = await getOriginalNames(intermediateItems, constructorNames)
   const finalResults: OriginalPosition[] = []
   for (let i = 0; i < intermediateItems.length; i++) {
     const item = intermediateItems[i]
@@ -17,7 +27,7 @@ export const addOriginalNames = async (intermediateItems: readonly IntermediateI
     finalResults.push({
       column: item.column,
       line: item.line,
-      name: originalName || item.name || '',
+      name: originalName || (constructorNames ? '' : item.name) || '',
       source: item.source,
       sourcesHash: item.sourcesHash,
     })

--- a/packages/source-map-worker/src/parts/GetCleanPositionsMap2/GetCleanPositionsMap2.ts
+++ b/packages/source-map-worker/src/parts/GetCleanPositionsMap2/GetCleanPositionsMap2.ts
@@ -7,9 +7,10 @@ export const getCleanPositionsMap2 = async (
   classNames: boolean,
   hash: string,
   key: string,
+  constructorNames = false,
 ): Promise<readonly any[]> => {
   // TODO move original names to source map coordinator
-  const originalPositions = await SourceMap.getOriginalPositions(sourceMap, value, classNames, hash, key)
+  const originalPositions = await SourceMap.getOriginalPositions(sourceMap, value, classNames, hash, key, constructorNames)
   const cleanPositions = originalPositions.map(GetCleanPosition.getCleanPosition)
   return cleanPositions
 }

--- a/packages/source-map-worker/src/parts/SourceMap/SourceMap.ts
+++ b/packages/source-map-worker/src/parts/SourceMap/SourceMap.ts
@@ -28,6 +28,7 @@ export const getOriginalPositions = async (
   classNames: boolean,
   hash: string,
   sourceMapUrl?: string,
+  constructorNames = false,
 ): Promise<readonly OriginalPosition[]> => {
   Assert.object(sourceMap)
   Assert.array(positions)
@@ -42,7 +43,12 @@ export const getOriginalPositions = async (
         line: line + 1,
       })
       let codePath: string | null = null
-      if (classNames && originalPosition.source && originalPosition.line !== null && originalPosition.column !== null) {
+      if (
+        (classNames || constructorNames) &&
+        originalPosition.source &&
+        originalPosition.line !== null &&
+        originalPosition.column !== null
+      ) {
         const index: number = sourceMap.sources.indexOf(originalPosition.source)
         if (index !== -1) {
           const sourceFileRelativePath: string = sourceMap.sources[index]
@@ -68,7 +74,7 @@ export const getOriginalPositions = async (
     return intermediateItems
   })
 
-  const finalResults: readonly OriginalPosition[] = await AddOriginalNames.addOriginalNames(intermediateItems)
+  const finalResults: readonly OriginalPosition[] = await AddOriginalNames.addOriginalNames(intermediateItems, constructorNames)
 
   return finalResults
 }


### PR DESCRIPTION
## Summary

Resolve tracked-allocation locations and constructor types against the source maps recorded for the instrumented VS Code runtime.

Tracked allocations retain paths from the original runtime, while Debugger.scriptParsed reports vscode-file URLs from the instrumented runtime. The resolver now normalizes the VS Code file scheme and matches the stable path below resources/app, allowing generated allocation coordinates to map back to their original sources.

The source-map pipeline also has a dedicated constructor-invocation mode. It parses the mapped source position, resolves the containing new expression, and exposes the result as originalType. Intrinsic and non-constructor allocations fall back to their tracked type.

Regression tests cover the runtime path mismatch, constructor invocations, nested constructors, member constructors, non-constructor allocations, and result serialization.

## Validation

- Focused original-name and tracked-allocation tests passed.
- TypeScript type checking passed.
- The requested editor-open tracked-allocations CLI run passed.
- All 1,885 tracked-allocation rows contained original location and originalType data; 673 constructor types were de-minified.
- Verified Eui resolves to DomListener at src/vs/base/browser/dom.ts:257:8.