### PR TITLE
fix: add tracked allocation original type

### DIFF
--- a/packages/memory-leak-finder/test/CompareTrackedAllocationLeaks.test.ts
+++ b/packages/memory-leak-finder/test/CompareTrackedAllocationLeaks.test.ts
@@ -73,6 +73,7 @@ test('compareTrackedAllocationLeaks returns only retained allocation sites in re
       originalLine: 245,
       originalLocation: 'src/prefixSumComputer.ts:245:9',
       originalSource: 'src/prefixSumComputer.ts',
+      originalType: 'PrefixSumComputer',
       type: 'PrefixSumComputer',
     },
     {
@@ -84,6 +85,7 @@ test('compareTrackedAllocationLeaks returns only retained allocation sites in re
       originalLine: null,
       originalLocation: null,
       originalSource: null,
+      originalType: 'Object',
       type: 'Object',
     },
   ])

--- a/packages/memory-leak-finder/test/MeasureTrackedAllocationLeaks.test.ts
+++ b/packages/memory-leak-finder/test/MeasureTrackedAllocationLeaks.test.ts
@@ -73,6 +73,7 @@ test('tracked allocation leak summary is informational and compact', async () =>
         originalLine: 10,
         originalLocation: 'src/a.ts:10:2',
         originalSource: 'src/a.ts',
+        originalType: 'Array',
         type: 'Array',
       },
     ]),


### PR DESCRIPTION
Add the required original allocation type to the tracked-allocation summary fixture so the main branch TypeScript build succeeds again.