### PR TITLE
fix: group event listeners by type

### DIFF
--- a/packages/memory-leak-finder/src/parts/GetEventListenerKey/GetEventListenerKey.ts
+++ b/packages/memory-leak-finder/src/parts/GetEventListenerKey/GetEventListenerKey.ts
@@ -1,13 +1,14 @@
 import type { Dynamic } from '../Types/Types.ts'
 import * as Assert from '../Assert/Assert.ts'
 export const getEventListenerKey = (listener: Dynamic) => {
+  Assert.string(listener.type)
   if ('location' in listener) {
-    return listener.location
+    return JSON.stringify([listener.type, listener.location])
   }
   if ('stack' in listener) {
-    return listener.stack.join('')
+    return JSON.stringify([listener.type, listener.stack.join('')])
   }
   Assert.number(listener.lineNumber)
   Assert.number(listener.columnNumber)
-  return `${listener.lineNumber}:${listener.columnNumber}`
+  return JSON.stringify([listener.type, listener.lineNumber, listener.columnNumber])
 }

--- a/packages/memory-leak-finder/test/DeduplicateEventListeners.test.ts
+++ b/packages/memory-leak-finder/test/DeduplicateEventListeners.test.ts
@@ -44,3 +44,42 @@ test('deduplicateEventListeners', () => {
     },
   ])
 })
+
+test('deduplicateEventListeners keeps event types separate at the same location', () => {
+  const stack = ['listener (file:///framework.js:1:2)']
+  const eventListeners = [
+    {
+      description: 'listener',
+      objectId: '1',
+      sourceMaps: [''],
+      stack,
+      type: 'click',
+    },
+    {
+      description: 'listener',
+      objectId: '2',
+      sourceMaps: [''],
+      stack,
+      type: 'keydown',
+    },
+  ]
+
+  expect(DeduplicateEventListeners.deduplicateEventListeners(eventListeners)).toEqual([
+    {
+      count: 1,
+      description: 'listener',
+      objectId: '1',
+      sourceMaps: [''],
+      stack,
+      type: 'click',
+    },
+    {
+      count: 1,
+      description: 'listener',
+      objectId: '2',
+      sourceMaps: [''],
+      stack,
+      type: 'keydown',
+    },
+  ])
+})

--- a/packages/memory-leak-finder/test/GetEventListenerKey.test.ts
+++ b/packages/memory-leak-finder/test/GetEventListenerKey.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@jest/globals'
+import * as GetEventListenerKey from '../src/parts/GetEventListenerKey/GetEventListenerKey.ts'
+
+test('getEventListenerKey includes the event type for locations', () => {
+  const click = GetEventListenerKey.getEventListenerKey({
+    location: 'file:///framework.js:1:2',
+    type: 'click',
+  })
+  const keydown = GetEventListenerKey.getEventListenerKey({
+    location: 'file:///framework.js:1:2',
+    type: 'keydown',
+  })
+
+  expect(click).not.toBe(keydown)
+})
+
+test('getEventListenerKey includes the event type for stacks', () => {
+  const stack = ['listener (file:///framework.js:1:2)']
+  const click = GetEventListenerKey.getEventListenerKey({
+    stack,
+    type: 'click',
+  })
+  const keydown = GetEventListenerKey.getEventListenerKey({
+    stack,
+    type: 'keydown',
+  })
+
+  expect(click).not.toBe(keydown)
+})
+
+test('getEventListenerKey includes the event type for line and column locations', () => {
+  const click = GetEventListenerKey.getEventListenerKey({
+    columnNumber: 2,
+    lineNumber: 1,
+    type: 'click',
+  })
+  const keydown = GetEventListenerKey.getEventListenerKey({
+    columnNumber: 2,
+    lineNumber: 1,
+    type: 'keydown',
+  })
+
+  expect(click).not.toBe(keydown)
+})

--- a/packages/memory-leak-finder/test/MeasureTrackedAllocationLeaks.test.ts
+++ b/packages/memory-leak-finder/test/MeasureTrackedAllocationLeaks.test.ts
@@ -73,6 +73,7 @@ test('tracked allocation leak summary is informational and compact', async () =>
         originalLine: 10,
         originalLocation: 'src/a.ts:10:2',
         originalSource: 'src/a.ts',
+        originalType: 'Array',
         type: 'Array',
       },
     ]),


### PR DESCRIPTION
Includes the event type in event-listener comparison and deduplication keys so handlers at the same source location are reported in the correct groups.