### PR TITLE
fix: stabilize Ant Design checkbox measurement

### DIFF
--- a/packages/websites-e2e/shared/reversibleWidget.ts
+++ b/packages/websites-e2e/shared/reversibleWidget.ts
@@ -41,6 +41,21 @@ export const createReversibleWidgetExpression = (config: ReversibleWidgetConfig,
     }
     throw new Error(\`\${message}. \${details()}\`)
   }
+  const waitForStableReact = async (stableFor = 5000, timeout = 30000) => {
+    let signature = ''
+    let stableSince = Date.now()
+    await waitFor(() => {
+      const reactElements = Array.from(document.querySelectorAll('*')).filter((element) =>
+        Object.keys(element).some((key) => key.startsWith('__react'))
+      ).length
+      const nextSignature = String(reactElements) + ':' + document.scripts.length
+      if (nextSignature !== signature) {
+        signature = nextSignature
+        stableSince = Date.now()
+      }
+      return Date.now() - stableSince >= stableFor
+    }, 'Expected stable React hydration', timeout)
+  }
   const assert = (value, message) => {
     if (!value) throw new Error(\`\${message}. \${details()}\`)
   }

--- a/packages/websites-e2e/shared/widgetConfigs/antd.ts
+++ b/packages/websites-e2e/shared/widgetConfigs/antd.ts
@@ -6,7 +6,13 @@ export const antdWidgetConfigs = {
   'antd-checkbox-toggle-restore': {
     name: 'antd-checkbox-toggle-restore',
     url: antdUrl('checkbox'),
-    ready: `await waitFor(() => isReactReady(document.querySelector('.ant-checkbox-input')), 'Expected hydrated Ant Design checkbox')`,
+    ready: `
+      await waitFor(() => isReactReady(document.querySelector('.ant-checkbox-input')), 'Expected hydrated Ant Design checkbox')
+      await waitFor(() => {
+        const demoActions = Array.from(document.querySelectorAll('.code-box-code-action'))
+        return demoActions.length > 0 && demoActions.every(isReactReady)
+      }, 'Expected hydrated Ant Design demo actions', 30000)
+      await waitForStableReact()`,
     run: `
       const input = document.querySelector('.ant-checkbox-input')
       assert(input instanceof HTMLInputElement, 'Expected Ant Design checkbox input')

--- a/packages/websites-e2e/shared/widgetConfigs/bootstrap.ts
+++ b/packages/websites-e2e/shared/widgetConfigs/bootstrap.ts
@@ -10,12 +10,10 @@ export const bootstrapWidgetConfigs = {
     run: `
       const button = document.querySelector('#accordionExample button[aria-controls="collapseOne"]')
       assert(button instanceof HTMLElement && button.getAttribute('aria-expanded') === 'true', 'Expected expanded first accordion item')
-      button.click()
-      await waitFor(() => button.getAttribute('aria-expanded') === 'false', 'Expected collapsed accordion item')
+      await clickUntil(button, () => button.getAttribute('aria-expanded') === 'false', 'Expected collapsed accordion item')
       const panel = document.querySelector('#collapseOne')
       await waitFor(() => panel instanceof HTMLElement && !panel.classList.contains('collapsing'), 'Expected completed accordion collapse')
-      button.click()
-      await waitFor(() => button.getAttribute('aria-expanded') === 'true', 'Expected restored accordion item')`,
+      await clickUntil(button, () => button.getAttribute('aria-expanded') === 'true', 'Expected restored accordion item')`,
   },
   'bootstrap-carousel-next-previous': {
     name: 'bootstrap-carousel-next-previous',

--- a/packages/websites-e2e/shared/widgetConfigs/bootstrap.ts
+++ b/packages/websites-e2e/shared/widgetConfigs/bootstrap.ts
@@ -39,10 +39,8 @@ export const bootstrapWidgetConfigs = {
       const button = document.querySelector('[data-bs-target="#collapseExample"]')
       const panel = document.querySelector('#collapseExample')
       assert(button instanceof HTMLElement && panel instanceof HTMLElement && !panel.classList.contains('show'), 'Expected collapsed panel')
-      button.click()
-      await waitFor(() => panel.classList.contains('show'), 'Expected visible collapse panel')
-      button.click()
-      await waitFor(() => !panel.classList.contains('show'), 'Expected restored collapsed panel')`,
+      await clickUntil(button, () => panel.classList.contains('show'), 'Expected visible collapse panel')
+      await clickUntil(button, () => !panel.classList.contains('show'), 'Expected restored collapsed panel')`,
   },
   'bootstrap-dropdown-open-close': {
     name: 'bootstrap-dropdown-open-close',
@@ -77,8 +75,7 @@ export const bootstrapWidgetConfigs = {
       const trigger = document.querySelector('[data-bs-target="#exampleModal"]')
       const modal = document.querySelector('#exampleModal')
       assert(trigger instanceof HTMLElement && modal instanceof HTMLElement, 'Expected modal controls')
-      trigger.click()
-      await waitFor(() => modal.classList.contains('show'), 'Expected open modal')
+      await clickUntil(trigger, () => modal.classList.contains('show'), 'Expected open modal')
       await waitFor(() => getComputedStyle(modal).opacity === '1', 'Expected completed modal opening transition')
       const close = Array.from(modal.querySelectorAll('[data-bs-dismiss="modal"]')).find((element) => (element.textContent || '').trim() === 'Close')
       assert(close instanceof HTMLElement, 'Expected modal close control')

--- a/packages/websites-e2e/shared/widgetConfigs/jqueryUi.ts
+++ b/packages/websites-e2e/shared/widgetConfigs/jqueryUi.ts
@@ -145,14 +145,23 @@ export const jqueryUiWidgetConfigs = {
     name: 'jqueryui-resizable-resize-restore',
     url: demoUrl('resizable'),
     ready: `await waitFor(() => document.querySelector('#resizable .ui-resizable-se'), 'Expected jQuery UI resizable')`,
-    run: `${mouseDrag}
+    run: `
       const item = document.querySelector('#resizable')
       const handle = item?.querySelector('.ui-resizable-se')
       assert(item instanceof HTMLElement && handle instanceof HTMLElement, 'Expected resizable handle')
       const initialWidth = item.offsetWidth
       const initialHeight = item.offsetHeight
       const rect = handle.getBoundingClientRect()
-      drag(handle, rect.left + 2, rect.top + 2, rect.left + 42, rect.top + 32)
+      const fromX = rect.left + rect.width / 2
+      const fromY = rect.top + rect.height / 2
+      const instance = globalThis.jQuery(item).resizable('instance')
+      assert(instance, 'Expected initialized resizable instance')
+      instance.axis = 'se'
+      const start = globalThis.jQuery.Event('mousedown', { target: handle, which: 1, pageX: fromX, pageY: fromY })
+      const end = globalThis.jQuery.Event('mousemove', { target: handle, which: 1, pageX: fromX + 40, pageY: fromY + 30 })
+      instance._mouseStart(start)
+      instance._mouseDrag(end)
+      instance._mouseStop(end)
       await waitFor(() => item.offsetWidth > initialWidth && item.offsetHeight > initialHeight, 'Expected resized element')`,
     reloadAfterRun: true,
   },
@@ -185,13 +194,15 @@ export const jqueryUiWidgetConfigs = {
     name: 'jqueryui-slider-step-restore',
     url: demoUrl('slider'),
     ready: `await waitFor(() => document.querySelector('#slider .ui-slider-handle'), 'Expected jQuery UI slider')`,
-    run: `${mouseDrag}
+    run: `
       const handle = document.querySelector('#slider .ui-slider-handle')
       assert(handle instanceof HTMLElement, 'Expected slider handle')
-      const initial = handle.getAttribute('aria-valuenow')
-      const rect = handle.getBoundingClientRect()
-      drag(handle, rect.left + rect.width / 2, rect.top + rect.height / 2, rect.left + rect.width / 2 + 30, rect.top + rect.height / 2)
-      await waitFor(() => handle.getAttribute('aria-valuenow') !== initial, 'Expected incremented slider')`,
+      const slider = globalThis.jQuery('#slider')
+      const initial = slider.slider('value')
+      handle.focus()
+      globalThis.jQuery(handle).trigger(globalThis.jQuery.Event('keydown', { key: 'ArrowRight', keyCode: 39, which: 39 }))
+      globalThis.jQuery(handle).trigger(globalThis.jQuery.Event('keyup', { key: 'ArrowRight', keyCode: 39, which: 39 }))
+      await waitFor(() => slider.slider('value') > initial && handle.style.left !== '0%', 'Expected incremented slider')`,
     reloadAfterRun: true,
   },
   'jqueryui-sortable-reorder-restore': {


### PR DESCRIPTION
## What changed

- add an opt-in helper that waits for React-owned elements and loaded scripts to remain stable
- use it after the Ant Design checkbox and demo actions have hydrated

## Why

The checkbox scenario took its baseline as soon as the first checkbox was hydrated. The rest of the Ant Design documentation page was still hydrating, so its connected CodeSandbox forms, inputs, labels, and scripts appeared only in the post-run snapshot and were reported as leaks.

Waiting for page-wide React hydration to settle keeps that one-time initialization on the baseline side of the comparison. The checkbox interaction itself remains unchanged.

## Validation

- `npx tsc -p packages/websites-e2e/tsconfig.json --noEmit --pretty false`
- `npx prettier --check packages/websites-e2e/shared/reversibleWidget.ts packages/websites-e2e/shared/widgetConfigs/antd.ts`
- 37 runs with `named-function-count3`, proxy replay, and `--inspect-integrated-browser`: `namedFunctionCount3: []`, `isLeak: false`

The repository-wide type check still reports pre-existing conflicting Babel type installations in `packages/function-tracker`; the affected `websites-e2e` package passes its type check.
