### PR TITLE
feature: add active async resource stack traces measure

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ npm run e2e
 
 ## Measures
 
+### ActiveAsyncResourcesWithStackTraces
+
+Tracks Node async resources created during the test and reports resources that remain active, grouped by resource type and creation stack. The tracker stores metadata only and removes its hook during capture.
+
+```sh
+node packages/cli/bin/test.js --cwd packages/e2e --check-leaks --measure-after --measure active-async-resources-with-stack-traces --only base
+```
+
 ### MemoryCity
 
 Captures allocation-aware renderer and extension-host heap snapshots, computes

--- a/packages/memory-leak-finder/src/parts/AsyncResourceTracker/AsyncResourceTracker.ts
+++ b/packages/memory-leak-finder/src/parts/AsyncResourceTracker/AsyncResourceTracker.ts
@@ -1,0 +1,86 @@
+import type { Session } from '../Session/Session.ts'
+import type { Dynamic } from '../Types/Types.ts'
+import { DevtoolsProtocolRuntime } from '../DevtoolsProtocol/DevtoolsProtocol.ts'
+
+const startExpression = `(() => {
+  globalThis.___memoryLeakFinderAsyncHook?.disable()
+  delete globalThis.___memoryLeakFinderAsyncHook
+  delete globalThis.___memoryLeakFinderAsyncResources
+  const getBuiltinModule = globalThis.process?.getBuiltinModule
+  const asyncHooks = typeof getBuiltinModule === 'function'
+    ? getBuiltinModule.call(globalThis.process, 'node:async_hooks')
+    : typeof globalThis.require === 'function'
+      ? globalThis.require('node:async_hooks')
+      : undefined
+  if (!asyncHooks) {
+    throw new Error('active-async-resources-with-stack-traces requires a Node target with async_hooks')
+  }
+  const resources = new Map()
+  const hook = asyncHooks.createHook({
+    init(asyncId, type, triggerAsyncId) {
+      const holder = {}
+      Error.captureStackTrace(holder, hook.callbacks?.init)
+      const stackTrace = String(holder.stack || new Error().stack || '')
+        .split('\n')
+        .slice(1)
+        .filter(line => !line.includes('node:internal/async_hooks'))
+      resources.set(asyncId, { asyncId, stackTrace, triggerAsyncId, type })
+    },
+    destroy(asyncId) {
+      resources.delete(asyncId)
+    },
+    promiseResolve(asyncId) {
+      resources.delete(asyncId)
+    },
+  })
+  globalThis.___memoryLeakFinderAsyncResources = resources
+  globalThis.___memoryLeakFinderAsyncHook = hook
+  hook.enable()
+})()`
+
+const stopExpression = `(() => {
+  const hook = globalThis.___memoryLeakFinderAsyncHook
+  const resources = globalThis.___memoryLeakFinderAsyncResources
+  hook?.disable()
+  try {
+    if (!(resources instanceof Map)) {
+      return []
+    }
+    const groups = new Map()
+    for (const item of resources.values()) {
+      const key = JSON.stringify([item.type, item.stackTrace])
+      let group = groups.get(key)
+      if (!group) {
+        group = { asyncIds: [], count: 0, stackTrace: item.stackTrace, triggerAsyncIds: [], type: item.type }
+        groups.set(key, group)
+      }
+      group.count++
+      if (group.asyncIds.length < 20) group.asyncIds.push(item.asyncId)
+      if (group.triggerAsyncIds.length < 20 && !group.triggerAsyncIds.includes(item.triggerAsyncId)) {
+        group.triggerAsyncIds.push(item.triggerAsyncId)
+      }
+    }
+    return [...groups.values()].sort((a, b) => b.count - a.count || a.type.localeCompare(b.type))
+  } finally {
+    delete globalThis.___memoryLeakFinderAsyncHook
+    delete globalThis.___memoryLeakFinderAsyncResources
+  }
+})()`
+
+const cleanupExpression = `(() => {
+  globalThis.___memoryLeakFinderAsyncHook?.disable()
+  delete globalThis.___memoryLeakFinderAsyncHook
+  delete globalThis.___memoryLeakFinderAsyncResources
+})()`
+
+export const start = async (session: Session): Promise<void> => {
+  await DevtoolsProtocolRuntime.evaluate(session, { expression: startExpression, returnByValue: true })
+}
+
+export const stop = async (session: Session): Promise<readonly Dynamic[]> => {
+  return await DevtoolsProtocolRuntime.evaluate(session, { expression: stopExpression, returnByValue: true })
+}
+
+export const cleanup = async (session: Session): Promise<void> => {
+  await DevtoolsProtocolRuntime.evaluate(session, { expression: cleanupExpression, returnByValue: true })
+}

--- a/packages/memory-leak-finder/src/parts/CompareActiveAsyncResources/CompareActiveAsyncResources.ts
+++ b/packages/memory-leak-finder/src/parts/CompareActiveAsyncResources/CompareActiveAsyncResources.ts
@@ -1,0 +1,16 @@
+import type { Dynamic, MeasureContext } from '../Types/Types.ts'
+
+export interface ActiveAsyncResourcesReport {
+  readonly isLeak: boolean
+  readonly resources: readonly Dynamic[]
+}
+
+export const compareActiveAsyncResources = (
+  _before: unknown,
+  after: readonly Dynamic[],
+  context: MeasureContext,
+): ActiveAsyncResourcesReport => {
+  const minimumCount = typeof context.runs === 'number' && Number.isFinite(context.runs) ? Math.max(1, context.runs) : 1
+  const resources = after.filter((item) => typeof item?.count === 'number' && item.count >= minimumCount)
+  return { isLeak: resources.length > 0, resources }
+}

--- a/packages/memory-leak-finder/src/parts/MeasureActiveAsyncResourcesWithStackTraces/MeasureActiveAsyncResourcesWithStackTraces.ts
+++ b/packages/memory-leak-finder/src/parts/MeasureActiveAsyncResourcesWithStackTraces/MeasureActiveAsyncResourcesWithStackTraces.ts
@@ -1,0 +1,50 @@
+import type { Session } from '../Session/Session.ts'
+import type { Dynamic, MeasureContext } from '../Types/Types.ts'
+import * as AsyncResourceTracker from '../AsyncResourceTracker/AsyncResourceTracker.ts'
+import * as CompareActiveAsyncResources from '../CompareActiveAsyncResources/CompareActiveAsyncResources.ts'
+import * as MeasureId from '../MeasureId/MeasureId.ts'
+import * as TargetId from '../TargetId/TargetId.ts'
+
+interface AsyncResourceState {
+  active: boolean
+}
+
+interface AsyncResourceCapture {
+  readonly resources: readonly Dynamic[]
+}
+
+export const id = MeasureId.ActiveAsyncResourcesWithStackTraces
+export const targets = [TargetId.Node]
+
+export const create = (session: Session) => {
+  return [session, { active: false } satisfies AsyncResourceState] as const
+}
+
+export const start = async (session: Session, state: AsyncResourceState): Promise<readonly Dynamic[]> => {
+  await AsyncResourceTracker.start(session)
+  state.active = true
+  return []
+}
+
+export const stop = async (session: Session, state: AsyncResourceState): Promise<AsyncResourceCapture> => {
+  const resources = await AsyncResourceTracker.stop(session)
+  state.active = false
+  return { resources }
+}
+
+export const compare = (_before: unknown, after: AsyncResourceCapture, context: MeasureContext): Dynamic => {
+  return CompareActiveAsyncResources.compareActiveAsyncResources(undefined, after.resources, context)
+}
+
+export const isLeak = (result: Dynamic): boolean => result?.isLeak === true
+
+export const releaseResources = async (session: Session, state: AsyncResourceState): Promise<void> => {
+  if (state.active) {
+    state.active = false
+    try {
+      await AsyncResourceTracker.cleanup(session)
+    } catch {
+      // The inspected process may already be gone.
+    }
+  }
+}

--- a/packages/memory-leak-finder/src/parts/MeasureId/MeasureId.ts
+++ b/packages/memory-leak-finder/src/parts/MeasureId/MeasureId.ts
@@ -1,5 +1,6 @@
 export const AbortControllerCount = 'abortControllerCount'
 export const AbortSignalCount = 'abortSignalCount'
+export const ActiveAsyncResourcesWithStackTraces = 'activeAsyncResourcesWithStackTraces'
 export const ArrayCount = 'arrayCount'
 export const ArrayElementCount = 'arrayElementCount'
 export const AttachedDomNodeCount = 'attachedDomNodeCount'

--- a/packages/memory-leak-finder/src/parts/Measures/Measures.ts
+++ b/packages/memory-leak-finder/src/parts/Measures/Measures.ts
@@ -1,5 +1,6 @@
 export * as MeasureAbortControllerCount from '../MeasureAbortControllerCount/MeasureAbortControllerCount.ts'
 export * as MeasureAbortSignalCount from '../MeasureAbortSignalCount/MeasureAbortSignalCount.ts'
+export * as MeasureActiveAsyncResourcesWithStackTraces from '../MeasureActiveAsyncResourcesWithStackTraces/MeasureActiveAsyncResourcesWithStackTraces.ts'
 export * as MeasureArrayCount from '../MeasureArrayCount/MeasureArrayCount.ts'
 export * as MeasureArrayElementCount from '../MeasureArrayElementCount/MeasureArrayElementCount.ts'
 export * as MeasureAttachedDomNodeCount from '../MeasureAttachedDomNodeCount/MeasureAttachedDomNodeCount.ts'

--- a/packages/memory-leak-finder/test/CompareActiveAsyncResources.test.ts
+++ b/packages/memory-leak-finder/test/CompareActiveAsyncResources.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from '@jest/globals'
+import { compareActiveAsyncResources } from '../src/parts/CompareActiveAsyncResources/CompareActiveAsyncResources.ts'
+
+test('keeps resource groups that recur once per measured run', () => {
+  const after = [
+    { count: 3, stackTrace: ['at leak (test.js:1:1)'], type: 'Timeout' },
+    { count: 1, stackTrace: ['at noise (test.js:2:1)'], type: 'PROMISE' },
+  ]
+  expect(compareActiveAsyncResources(undefined, after, { runs: 3 })).toEqual({ isLeak: true, resources: [after[0]] })
+})

--- a/packages/memory-leak-finder/test/MeasureActiveAsyncResourcesWithStackTraces.test.ts
+++ b/packages/memory-leak-finder/test/MeasureActiveAsyncResourcesWithStackTraces.test.ts
@@ -1,0 +1,23 @@
+import { expect, jest, test } from '@jest/globals'
+
+const trackerStart = jest.fn()
+const trackerStop = jest.fn()
+const cleanup = jest.fn()
+
+jest.unstable_mockModule('../src/parts/AsyncResourceTracker/AsyncResourceTracker.ts', () => ({
+  cleanup,
+  start: trackerStart,
+  stop: trackerStop,
+}))
+
+const Measure = await import('../src/parts/MeasureActiveAsyncResourcesWithStackTraces/MeasureActiveAsyncResourcesWithStackTraces.ts')
+
+test('starts the Node async hook, returns grouped live resources, and tears it down', async () => {
+  const session = {} as any
+  const [, state] = Measure.create(session)
+  trackerStop.mockImplementation(async () => [{ count: 2, stackTrace: [], type: 'Timeout' }])
+  await Measure.start(session, state)
+  const after = await Measure.stop(session, state)
+  expect(after.resources).toEqual([{ count: 2, stackTrace: [], type: 'Timeout' }])
+  expect(trackerStart).toHaveBeenCalledWith(session)
+})


### PR DESCRIPTION
## Summary

- add a Node-only measure based on async_hooks
- group resources that remain active by type and creation stack
- retain metadata rather than resource objects and remove the hook during capture

## Validation

- npm run type-check
- memory-leak-finder test suite
- npm run lint