### PR TITLE
fix: escape async resource tracker expression

### DIFF
--- a/packages/memory-leak-finder/src/parts/AsyncResourceTracker/AsyncResourceTracker.ts
+++ b/packages/memory-leak-finder/src/parts/AsyncResourceTracker/AsyncResourceTracker.ts
@@ -21,7 +21,7 @@ const startExpression = `(() => {
       const holder = {}
       Error.captureStackTrace(holder, hook.callbacks?.init)
       const stackTrace = String(holder.stack || new Error().stack || '')
-        .split('\n')
+        .split('\\n')
         .slice(1)
         .filter(line => !line.includes('node:internal/async_hooks'))
       resources.set(asyncId, { asyncId, stackTrace, triggerAsyncId, type })

--- a/packages/memory-leak-finder/test/AsyncResourceTracker.test.ts
+++ b/packages/memory-leak-finder/test/AsyncResourceTracker.test.ts
@@ -1,6 +1,6 @@
 import { expect, jest, test } from '@jest/globals'
 
-const evaluate = jest.fn(async () => undefined)
+const evaluate = jest.fn<(_session: unknown, options: { readonly expression: string }) => Promise<undefined>>(async () => undefined)
 
 jest.unstable_mockModule('../src/parts/DevtoolsProtocol/DevtoolsProtocol.ts', () => ({
   DevtoolsProtocolRuntime: { evaluate },
@@ -10,6 +10,10 @@ const AsyncResourceTracker = await import('../src/parts/AsyncResourceTracker/Asy
 
 test('injects syntactically valid JavaScript', async () => {
   await AsyncResourceTracker.start({} as any)
-  const expression = evaluate.mock.calls[0][1].expression
+  const call = evaluate.mock.calls[0]
+  if (!call) {
+    throw new Error('Expected DevtoolsProtocolRuntime.evaluate to be called')
+  }
+  const expression = call[1].expression
   expect(() => new Function(expression)).not.toThrow()
 })

--- a/packages/memory-leak-finder/test/AsyncResourceTracker.test.ts
+++ b/packages/memory-leak-finder/test/AsyncResourceTracker.test.ts
@@ -1,0 +1,15 @@
+import { expect, jest, test } from '@jest/globals'
+
+const evaluate = jest.fn(async () => undefined)
+
+jest.unstable_mockModule('../src/parts/DevtoolsProtocol/DevtoolsProtocol.ts', () => ({
+  DevtoolsProtocolRuntime: { evaluate },
+}))
+
+const AsyncResourceTracker = await import('../src/parts/AsyncResourceTracker/AsyncResourceTracker.ts')
+
+test('injects syntactically valid JavaScript', async () => {
+  await AsyncResourceTracker.start({} as any)
+  const expression = evaluate.mock.calls[0][1].expression
+  expect(() => new Function(expression)).not.toThrow()
+})


### PR DESCRIPTION
## Summary

- emit a valid newline escape in the injected async-hooks tracker
- add regression coverage that parses the generated JavaScript expression