### PR TITLE
fix: parse native context names

### DIFF
--- a/packages/heap-snapshot-worker/src/parts/CompareNativeContextCount/CompareNativeContextCount.ts
+++ b/packages/heap-snapshot-worker/src/parts/CompareNativeContextCount/CompareNativeContextCount.ts
@@ -9,7 +9,10 @@ export interface NativeContextCountComparison {
 }
 
 export const compareNativeContextCount = async (beforePath: string, afterPath: string): Promise<NativeContextCountComparison> => {
-  const [beforeSnapshot, afterSnapshot] = await Promise.all([prepareHeapSnapshot(beforePath, {}), prepareHeapSnapshot(afterPath, {})])
+  const [beforeSnapshot, afterSnapshot] = await Promise.all([
+    prepareHeapSnapshot(beforePath, { parseStrings: true }),
+    prepareHeapSnapshot(afterPath, { parseStrings: true }),
+  ])
   const before = getNativeContextCount(beforeSnapshot)
   const after = getNativeContextCount(afterSnapshot)
   const delta = after - before

--- a/packages/heap-snapshot-worker/src/parts/GetNativeContextCount/GetNativeContextCount.ts
+++ b/packages/heap-snapshot-worker/src/parts/GetNativeContextCount/GetNativeContextCount.ts
@@ -12,7 +12,7 @@ export const getNativeContextCount = (snapshot: Snapshot): number => {
       continue
     }
     const name = snapshot.strings[snapshot.nodes[index + nameOffset]]
-    if (name === 'system / NativeContext' || name.startsWith('system / NativeContext / ')) {
+    if (typeof name === 'string' && (name === 'system / NativeContext' || name.startsWith('system / NativeContext / '))) {
       count++
     }
   }

--- a/packages/heap-snapshot-worker/test/GetNativeContextCount.test.ts
+++ b/packages/heap-snapshot-worker/test/GetNativeContextCount.test.ts
@@ -15,8 +15,8 @@ test('counts hidden V8 NativeContext nodes, including URL-qualified contexts', (
       node_fields: ['type', 'name', 'id', 'self_size', 'edge_count'],
       node_types: [['hidden', 'string']],
     },
-    node_count: 4,
-    nodes: new Uint32Array([0, 1, 1, 1244, 0, 0, 2, 3, 1244, 0, 0, 3, 5, 64, 0, 1, 4, 7, 0, 0]),
+    node_count: 5,
+    nodes: new Uint32Array([0, 1, 1, 1244, 0, 0, 2, 3, 1244, 0, 0, 3, 5, 64, 0, 1, 4, 7, 0, 0, 0, 99, 9, 0, 0]),
     strings: ['', 'system / NativeContext', 'system / NativeContext / vscode-file://vscode-app', 'system / Context', 'NativeContext'],
   }
   expect(getNativeContextCount(snapshot)).toBe(2)


### PR DESCRIPTION
## Summary

- parse heap snapshot strings before counting native contexts
- tolerate malformed name indexes while scanning hidden nodes