### PR TITLE
fix: cancel superseded ci runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read

--- a/packages/build/test/CiWorkflow.test.ts
+++ b/packages/build/test/CiWorkflow.test.ts
@@ -9,6 +9,14 @@ const getWorkflowPath = (): string => {
   return join(testDir, '..', '..', '..', '.github', 'workflows', 'ci.yml')
 }
 
+test('ci cancels superseded runs before starting the measure matrix', async () => {
+  const workflow = await readFile(getWorkflowPath(), 'utf8')
+
+  expect(workflow).toContain(`concurrency:
+  group: ci-\${{ github.ref }}
+  cancel-in-progress: true`)
+})
+
 test('ci measure failures do not block the Pages deployment', async () => {
   const workflow = await readFile(getWorkflowPath(), 'utf8')
 


### PR DESCRIPTION
## Summary

- cancel older CI runs when a newer commit reaches the same branch
- prevent the expensive measure matrix from accumulating behind stale pushes
- add a regression test for the workflow concurrency policy

## Diagnosis

Recent pushes started roughly 45 measure jobs each while the slowest job takes almost six hours. Because the workflow had no concurrency policy, rapid main pushes saturated the available runners and left later workflows queued for hours until they were cancelled.

## Verification

- npm test
- npm run type-check
- npm --prefix packages/build test -- --runInBand test/CiWorkflow.test.ts
- npx prettier --check .github/workflows/ci.yml packages/build/test/CiWorkflow.test.ts