### PR TITLE
fix: wait before detached DOM measurements in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           - name: dom-counters
             args: --measure dom-counters
           - name: detached-dom-node-count
-            args: --measure detached-dom-node-count
+            args: --measure detached-dom-node-count --timeout-between 10000
           - name: promise-count
             args: --measure promise-count
           - name: promises-with-stack-trace

--- a/packages/test-coordinator/src/parts/RunTestsWithCallback/RunTestsWithCallback.ts
+++ b/packages/test-coordinator/src/parts/RunTestsWithCallback/RunTestsWithCallback.ts
@@ -893,10 +893,6 @@ export const runTestsWithCallback = async ({
               }
               await MemoryLeakFinder.stop(memoryRpc, connectionId)
 
-              if (measureAfter) {
-                await Timeout.setTimeout(3000)
-              }
-
               result = await MemoryLeakFinder.compare(memoryRpc, connectionId, context, resultPath)
             }
             if (result.isLeak) {


### PR DESCRIPTION
## Summary

- wait 10 seconds for asynchronous cleanup before capturing the detached DOM node After measurement in CI
- remove the ineffective three-second delay that ran after the After snapshot had already been captured

## Why

Detached DOM nodes can remain temporarily while delayed disposal work is still pending. The existing `measure-after` delay ran only after `MemoryLeakFinder.stop()`, but `stop()` is what captures the After value, so that delay could not reduce false positives.

The detached DOM CI job now uses the existing `--timeout-between 10000` option, which waits immediately before `stop()` and therefore before the After snapshot. Other measure jobs are unaffected.

## Validation

- `npm --prefix packages/test-coordinator test -- --runInBand`
- `npm run lint`
- `npm run type-check`
