### PR TITLE
feature: improve chat terminal test

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -83,9 +83,7 @@ jobs:
           run: node packages/cli/bin/test.js --cwd packages/e2e --check-leaks --measure event-listeners
       - name: Run Memory City smoke test
         if: matrix.os == 'ubuntu-24.04'
-        uses: coactions/setup-xvfb@v1
-        with:
-          run: node packages/cli/bin/test.js --cwd packages/e2e --check-leaks --measure memory-city --only ^editor-open.ts --workers 1
+        run: timeout 5m xvfb-run --auto-servernum node packages/cli/bin/test.js --cwd packages/e2e --check-leaks --measure memory-city --only ^editor-open.ts --workers 1
       - name: Generate charts
         run: node packages/charts/src/main.ts
       - name: Validate Memory City artifact

--- a/packages/build/test/CiWorkflow.test.ts
+++ b/packages/build/test/CiWorkflow.test.ts
@@ -3,10 +3,10 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { expect, test } from '@jest/globals'
 
-const getWorkflowPath = (): string => {
+const getWorkflowPath = (workflowName = 'ci.yml'): string => {
   const currentFilePath = fileURLToPath(import.meta.url)
   const testDir = dirname(currentFilePath)
-  return join(testDir, '..', '..', '..', '.github', 'workflows', 'ci.yml')
+  return join(testDir, '..', '..', '..', '.github', 'workflows', workflowName)
 }
 
 test('ci cancels superseded runs before starting the measure matrix', async () => {
@@ -26,4 +26,12 @@ test('ci measure failures do not block the Pages deployment', async () => {
         uses: coactions/setup-xvfb@v1`)
   expect(workflow).toContain(`  deploy:
     if: \${{ always() && needs.ci.result == 'success' && needs.ci-linux-charts.result == 'success' }}`)
+})
+
+test('pr bounds the Memory City smoke test without the setup-xvfb action wrapper', async () => {
+  const workflow = await readFile(getWorkflowPath('pr.yml'), 'utf8')
+
+  expect(workflow).toContain(`      - name: Run Memory City smoke test
+        if: matrix.os == 'ubuntu-24.04'
+        run: timeout 5m xvfb-run --auto-servernum node packages/cli/bin/test.js --cwd packages/e2e --check-leaks --measure memory-city --only ^editor-open.ts --workers 1`)
 })

--- a/packages/e2e/src/chat-editor-execute-terminal-command.ts
+++ b/packages/e2e/src/chat-editor-execute-terminal-command.ts
@@ -8,21 +8,14 @@ export const setup = async ({ ChatEditor, SideBar, Editor }: TestContext): Promi
   await Editor.closeAll()
   await SideBar.hide()
   await ChatEditor.open()
+  await ChatEditor.clearAll()
 }
 
 export const run = async ({ ChatEditor, Terminal }: TestContext): Promise<void> => {
   await ChatEditor.sendMessage({
-    message: `Run echo hello world in terminal.`,
+    message: `Use the terminal tool to run exactly: echo hello world`,
     model: ChatEditor.Models.Auto,
     approveToolCalls: true,
-    // @ts-ignore
-    compactToolInvocations: true,
-    toolInvocations: [
-      {
-        content: `echo hello world`,
-        type: 'terminal',
-      },
-    ],
     verify: true,
   })
 


### PR DESCRIPTION
## Details

- Refresh the branch with the latest `main`.
- Clear the chat before the terminal-tool scenario and exercise the real terminal invocation with `echo hello world`.
- Run the final Memory City smoke test through a direct, five-minute-bounded `xvfb-run` command. The repeated setup-xvfb action had a missing cleanup script and could leave the last Linux step hanging until the four-hour job timeout.
- Add workflow regression coverage for the bounded command.

## Verification

- `npm run type-check`
- `npm run lint`
- `npm test -- --since origin/main`
- `npm --prefix packages/build test -- --runInBand CiWorkflow.test.ts`
- Local Memory City smoke test
- GitHub Actions on Linux, macOS, and Windows