### PR TITLE
feature: add accessibility help memory e2e test

### DIFF
--- a/packages/e2e/src/editor-accessibility-help-churn.ts
+++ b/packages/e2e/src/editor-accessibility-help-churn.ts
@@ -1,0 +1,27 @@
+import type { TestContext } from '../types.ts'
+
+export const skip = 1
+
+export const setup = async ({ Editor, Workspace }: TestContext): Promise<void> => {
+  await Workspace.setFiles([
+    {
+      content: '<main><h1>Accessibility lifecycle</h1></main>\n',
+      name: 'index.html',
+    },
+  ])
+  await Editor.closeAll()
+  await Editor.goToFile({
+    column: 8,
+    file: 'index.html',
+    line: 1,
+  })
+}
+
+export const run = async ({ AccessibilityHelp }: TestContext): Promise<void> => {
+  await AccessibilityHelp.open()
+  await AccessibilityHelp.close()
+}
+
+export const teardown = async ({ Editor }: TestContext): Promise<void> => {
+  await Editor.closeAll()
+}

--- a/packages/e2e/types/pageobject-api.d.ts
+++ b/packages/e2e/types/pageobject-api.d.ts
@@ -73,6 +73,10 @@ export interface ActivityBar {
   showSearch(): Promise<void>
   showSourceControl(): Promise<void>
 }
+export interface AccessibilityHelp {
+  close(): Promise<void>
+  open(): Promise<void>
+}
 export interface CallHierarchy {
   close(): Promise<void>
   focusNext(): Promise<void>
@@ -966,6 +970,7 @@ export interface Workspace {
 
 export interface PageObjectApi {
   readonly ActivityBar: ActivityBar
+  readonly AccessibilityHelp: AccessibilityHelp
   readonly CallHierarchy: CallHierarchy
   readonly ChatEditor: ChatEditor
   readonly ColorPicker: ColorPicker

--- a/packages/page-object/src/parts/AccessibilityHelp/AccessibilityHelp.ts
+++ b/packages/page-object/src/parts/AccessibilityHelp/AccessibilityHelp.ts
@@ -1,0 +1,32 @@
+import type { CreateParams } from '../CreateParams/CreateParams.ts'
+import * as QuickPick from '../QuickPick/QuickPick.ts'
+
+export const create = ({ electronApp, expect, ideVersion, page, platform, VError }: CreateParams) => {
+  const getWidget = () => page.locator('.accessible-view-container .accessible-view')
+
+  return {
+    async close() {
+      try {
+        const widget = getWidget()
+        await expect(widget).toBeVisible()
+        await page.keyboard.press('Escape')
+        await page.waitForIdle()
+        await expect(widget).toBeHidden()
+      } catch (error) {
+        throw new VError(error, `Failed to close Accessibility Help`)
+      }
+    },
+    async open() {
+      try {
+        const quickPick = QuickPick.create({ electronApp, expect, ideVersion, page, platform, VError })
+        await quickPick.executeCommand('Open Accessibility Help')
+        const widget = getWidget()
+        await expect(widget).toBeVisible()
+        await expect(widget.locator('.accessible-view-title')).toHaveText('Accessibility Help')
+        await page.waitForIdle()
+      } catch (error) {
+        throw new VError(error, `Failed to open Accessibility Help`)
+      }
+    },
+  }
+}

--- a/packages/page-object/src/parts/Parts/Parts.ts
+++ b/packages/page-object/src/parts/Parts/Parts.ts
@@ -1,4 +1,5 @@
 export * as ActivityBar from '../ActivityBar/ActivityBar.ts'
+export * as AccessibilityHelp from '../AccessibilityHelp/AccessibilityHelp.ts'
 export * as CallHierarchy from '../CallHierarchy/CallHierarchy.ts'
 export * as ChatEditor from '../ChatEditor/ChatEditor.ts'
 export * as ColorPicker from '../ColorPicker/ColorPicker.ts'


### PR DESCRIPTION
## Details\n\n- add an Accessibility Help page object\n- add a deterministic open/close lifecycle scenario\n- verify the accessible view title and disposal path\n\n## Memory measurement\n\nA 37-cycle named-function-count3 run found MenuImpl, MenuInfo, and related menu-service closures growing by 37.\n\n## Validation\n\n- one-run E2E smoke test\n- TypeScript project build\n- Prettier and diff checks