### PR TITLE
feature: add notebook output memory e2e test

### DIFF
--- a/packages/e2e/src/notebook-static-output-open-close.ts
+++ b/packages/e2e/src/notebook-static-output-open-close.ts
@@ -1,0 +1,69 @@
+import type { TestContext } from '../types.ts'
+
+export const skip = 1
+
+const cells = Array.from({ length: 20 }, (_, index) => ({
+  cell_type: 'markdown',
+  metadata: {},
+  source: [`## Section ${index + 1}\n`, `Notebook lifecycle content ${index + 1}`],
+}))
+
+const notebook = {
+  cells: [
+    {
+      cell_type: 'code',
+      execution_count: 1,
+      metadata: {},
+      outputs: [
+        {
+          name: 'stdout',
+          output_type: 'stream',
+          text: ['static notebook output\n'],
+        },
+      ],
+      source: ['print("static notebook output")'],
+    },
+    ...cells,
+  ],
+  metadata: {
+    language_info: {
+      name: 'python',
+    },
+  },
+  nbformat: 4,
+  nbformat_minor: 2,
+}
+
+export const setup = async ({ Editor, Explorer, Workspace }: TestContext): Promise<void> => {
+  await Workspace.setFiles([
+    {
+      content: JSON.stringify(notebook, null, 2) + '\n',
+      name: 'static-output.ipynb',
+    },
+  ])
+  await Workspace.updateWorkspaceSettings({
+    'workbench.editorAssociations': {
+      '*.ipynb': 'jupyter-notebook',
+    },
+  })
+  await Editor.closeAll()
+  await Explorer.focus()
+  await Explorer.refresh()
+  await Explorer.shouldHaveItem('static-output.ipynb')
+}
+
+export const run = async ({ Editor, Explorer, Notebook }: TestContext): Promise<void> => {
+  try {
+    await Explorer.openItem('static-output.ipynb')
+    await Notebook.shouldHaveOutput('static notebook output\n')
+    await Notebook.scrollDown()
+    await Notebook.scrollUp()
+  } finally {
+    await Editor.closeAll()
+  }
+}
+
+export const teardown = async ({ Editor, Workspace }: TestContext): Promise<void> => {
+  await Editor.closeAll()
+  await Workspace.updateWorkspaceSettings({ 'workbench.editorAssociations': undefined })
+}

--- a/packages/e2e/types/pageobject-api.d.ts
+++ b/packages/e2e/types/pageobject-api.d.ts
@@ -547,6 +547,7 @@ export interface Notebook {
   removeMarkdownCell(): Promise<void>
   scrollDown(): Promise<void>
   scrollUp(): Promise<void>
+  shouldHaveOutput(expectedOutput: string): Promise<void>
   splitCell(cellIndex?: any): Promise<void>
 }
 export interface NotebookInlineChat {

--- a/packages/page-object/src/parts/Notebook/Notebook.ts
+++ b/packages/page-object/src/parts/Notebook/Notebook.ts
@@ -182,6 +182,24 @@ export const create = ({ electronApp, expect, ideVersion, page, platform, VError
         throw new VError(error, `Failed to scroll up in notebook`)
       }
     },
+    async shouldHaveOutput(expectedOutput: string) {
+      try {
+        const notebook = page.locator('.notebook-editor')
+        await expect(notebook).toBeVisible()
+        const outputContainer = page.locator('.notebookOverlay .output-inner-container')
+        await expect(outputContainer).toBeVisible({ timeout: 15_000 })
+        const url = /purpose=notebookRenderer/
+        const childPage = await page.waitForIframe({
+          injectUtilityScript: false,
+          url,
+        })
+        const notebookOutput = await childPage.waitForSubIframe({ url })
+        await expect(notebookOutput.locator('.output_container')).toHaveText(expectedOutput, { timeout: 15_000 })
+        await page.waitForIdle()
+      } catch (error) {
+        throw new VError(error, `Failed to verify notebook output ${expectedOutput}`)
+      }
+    },
     async splitCell(cellIndex = 0) {
       try {
         await page.waitForIdle()


### PR DESCRIPTION
## Details\n\n- add a static notebook with a rendered stream output and twenty markdown cells\n- force the Jupyter notebook editor association\n- verify output rendering, scroll the notebook, and close it each cycle\n\n## Memory measurement\n\nA 37-cycle named-function-count3 run found five ResourceEditorInput listener closures growing by 74 each. The result remained after forcing the Jupyter association.\n\n## Validation\n\n- one-run E2E smoke test\n- TypeScript project build\n- Prettier and diff checks