### PR TITLE
feature: add extension detail memory e2e test

### DIFF
--- a/packages/e2e/src/extension-detail-view-lifecycle-churn.ts
+++ b/packages/e2e/src/extension-detail-view-lifecycle-churn.ts
@@ -1,0 +1,26 @@
+import type { TestContext } from '../types.ts'
+
+export const skip = 1
+
+export const setup = async ({ Editor, Extensions }: TestContext): Promise<void> => {
+  await Editor.closeAll()
+  await Extensions.show()
+  await Extensions.search('@builtin html')
+  await Extensions.first.shouldBe('HTML Language Basics')
+}
+
+export const run = async ({ Editor, ExtensionDetailView, Extensions }: TestContext): Promise<void> => {
+  try {
+    await Extensions.first.click()
+    await ExtensionDetailView.shouldHaveHeading('HTML Language Basics')
+    await ExtensionDetailView.openTab('Features', { timeout: 30_000, webView: false })
+    await ExtensionDetailView.openTab('Changelog', { timeout: 30_000, webView: true })
+    await ExtensionDetailView.openTab('Details', { timeout: 30_000, webView: true })
+  } finally {
+    await Editor.closeAll()
+  }
+}
+
+export const teardown = async ({ Editor }: TestContext): Promise<void> => {
+  await Editor.closeAll()
+}


### PR DESCRIPTION
## Details

- open the built-in HTML extension details on each cycle
- switch through Features, Changelog, and Details, including the extension webview
- close the extension editor before the next cycle

## Memory measurement

A 37-cycle named-function-count3 run completed without retained named functions.

## Validation

- one-run E2E smoke test
- TypeScript project build
- Prettier and diff checks