### PR TITLE
feature: add source control repository lifecycle memory e2e test

### DIFF
--- a/packages/e2e/src/source-control-repository-lifecycle-churn.ts
+++ b/packages/e2e/src/source-control-repository-lifecycle-churn.ts
@@ -1,0 +1,31 @@
+import type { TestContext } from '../types.ts'
+
+export const skip = 1
+
+export const setup = async ({ ActivityBar, Git, QuickPick, SourceControl, Workspace }: TestContext): Promise<void> => {
+  await Workspace.setFiles([
+    {
+      content: '# Lifecycle repository\n',
+      name: 'repository/README.md',
+    },
+  ])
+  await Git.initRepository('repository')
+  await QuickPick.waitForCommand('Git: Open Repository')
+  await Git.openRepository('repository')
+  await ActivityBar.showSourceControl()
+  await SourceControl.shouldHaveRepositoryCount(1)
+}
+
+export const run = async ({ Git, SourceControl }: TestContext): Promise<void> => {
+  await Git.closeRepository()
+  await SourceControl.shouldHaveRepositoryCount(0)
+
+  await Git.reopenClosedRepository('repository')
+  await SourceControl.shouldHaveRepositoryCount(1)
+}
+
+export const teardown = async ({ Git, SourceControl, Workspace }: TestContext): Promise<void> => {
+  await Git.closeRepository()
+  await SourceControl.shouldHaveRepositoryCount(0)
+  await Workspace.setFiles([])
+}


### PR DESCRIPTION
## Details

- add a source-control repository registration lifecycle scenario
- exercise closing and reopening a nested Git repository while verifying repository counts on every cycle

## Memory measurement

A 37-cycle `named-function-count3` run found `ResourceMapEntry` and `ConfigurationModel` each growing by 37.

## Validation

- one-run E2E smoke test
- TypeScript project build
- Prettier and diff checks