### PR TITLE
feature: add notebook editor lifecycle memory e2e test

### DIFF
--- a/packages/e2e/src/notebook-editor-lifecycle-churn.ts
+++ b/packages/e2e/src/notebook-editor-lifecycle-churn.ts
@@ -1,0 +1,59 @@
+import type { TestContext } from '../types.ts'
+
+export const skip = 1
+
+const notebook = {
+  cells: [
+    {
+      cell_type: 'code',
+      metadata: {},
+      source: ['print("first line")\n', 'print("second line")'],
+    },
+    {
+      cell_type: 'markdown',
+      metadata: {},
+      source: ['## Lifecycle notebook\n'],
+    },
+  ],
+  metadata: {
+    language_info: {
+      name: 'python',
+    },
+  },
+  nbformat: 4,
+  nbformat_minor: 2,
+}
+
+export const setup = async ({ Editor, Explorer, Workspace }: TestContext): Promise<void> => {
+  await Workspace.setFiles([
+    {
+      content: JSON.stringify(notebook, null, 2) + '\n',
+      name: 'editor-lifecycle.ipynb',
+    },
+  ])
+  await Workspace.updateWorkspaceSettings({
+    'workbench.editorAssociations': {
+      '*.ipynb': 'jupyter-notebook',
+    },
+  })
+  await Editor.closeAll()
+  await Explorer.focus()
+  await Explorer.refresh()
+  await Explorer.shouldHaveItem('editor-lifecycle.ipynb')
+}
+
+export const run = async ({ Editor, Explorer, Notebook }: TestContext): Promise<void> => {
+  try {
+    await Explorer.openItem('editor-lifecycle.ipynb')
+    await Notebook.splitCell(0)
+    await Notebook.mergeCell(0)
+    await Editor.saveAll()
+  } finally {
+    await Editor.closeAll()
+  }
+}
+
+export const teardown = async ({ Editor, Workspace }: TestContext): Promise<void> => {
+  await Editor.closeAll()
+  await Workspace.updateWorkspaceSettings({ 'workbench.editorAssociations': undefined })
+}


### PR DESCRIPTION
## Details

- add a notebook editor and cell-model lifecycle scenario
- exercise notebook opening, cell split and merge edits, saving, and editor disposal on every cycle

## Memory measurement

A 37-cycle `named-function-count3` run found 23 retained rows, including notebook cell text models, piece trees, undo/redo groups, cell edits, resource inputs, and related closures.

## Validation

- one-run E2E smoke test
- TypeScript project build
- Prettier and diff checks