### PR TITLE
feature: add editor find replace lifecycle memory e2e test

### DIFF
--- a/packages/e2e/src/editor-find-replace-lifecycle-churn.ts
+++ b/packages/e2e/src/editor-find-replace-lifecycle-churn.ts
@@ -1,0 +1,36 @@
+import type { TestContext } from '../types.ts'
+
+export const skip = 1
+
+export const setup = async ({ Editor, Workspace }: TestContext): Promise<void> => {
+  await Workspace.setFiles([
+    {
+      content: '<h1>abc</h1>',
+      name: 'index.html',
+    },
+  ])
+  await Editor.closeAll()
+  await Editor.open('index.html')
+  await Editor.shouldHaveText('<h1>abc</h1>')
+}
+
+export const run = async ({ Editor, EditorFind }: TestContext): Promise<void> => {
+  try {
+    await Editor.openFind()
+    await EditorFind.setSearchValue('abc')
+    await EditorFind.openReplace()
+    await EditorFind.setReplaceValue('def')
+    await EditorFind.replace()
+    await Editor.shouldHaveText('<h1>def</h1>')
+    await EditorFind.setSearchValue('def')
+    await EditorFind.setReplaceValue('abc')
+    await EditorFind.replace()
+    await Editor.shouldHaveText('<h1>abc</h1>')
+  } finally {
+    await Editor.closeFind()
+  }
+}
+
+export const teardown = async ({ Editor }: TestContext): Promise<void> => {
+  await Editor.closeAll()
+}

--- a/packages/e2e/src/editor-find-replace-lifecycle-churn.ts
+++ b/packages/e2e/src/editor-find-replace-lifecycle-churn.ts
@@ -32,5 +32,6 @@ export const run = async ({ Editor, EditorFind }: TestContext): Promise<void> =>
 }
 
 export const teardown = async ({ Editor }: TestContext): Promise<void> => {
+  await Editor.save({ viaKeyBoard: true })
   await Editor.closeAll()
 }


### PR DESCRIPTION
Adds a focused skipped E2E scenario that repeatedly opens the editor find/replace widget, replaces text in both directions, and closes the widget.

This gives the memory runner a deterministic lifecycle for detecting retained find/replace widget state.