### PR TITLE
feature: add suggest widget lifecycle memory e2e test

### DIFF
--- a/packages/e2e/src/suggest-widget-lifecycle-churn.ts
+++ b/packages/e2e/src/suggest-widget-lifecycle-churn.ts
@@ -1,0 +1,25 @@
+import type { TestContext } from '../types.ts'
+
+export const skip = 1
+
+export const setup = async ({ Editor, Workspace }: TestContext): Promise<void> => {
+  await Workspace.setFiles([
+    {
+      content: '<h1><spa</h1>',
+      name: 'index.html',
+    },
+  ])
+  await Editor.closeAll()
+  await Editor.open('index.html')
+  await Editor.shouldHaveText('<h1><spa</h1>')
+  await Editor.setCursor(1, 9)
+}
+
+export const run = async ({ Suggest }: TestContext): Promise<void> => {
+  await Suggest.open('span, Property')
+  await Suggest.close()
+}
+
+export const teardown = async ({ Editor }: TestContext): Promise<void> => {
+  await Editor.closeAll()
+}


### PR DESCRIPTION
Adds a focused skipped E2E scenario that repeatedly opens and dismisses HTML completion suggestions.

This gives the memory runner a deterministic suggest-widget lifecycle backed by the built-in HTML language service.