### PR TITLE
feature: add welcome walkthrough lifecycle memory e2e test

### DIFF
--- a/packages/e2e/src/welcome-walkthrough-lifecycle-churn.ts
+++ b/packages/e2e/src/welcome-walkthrough-lifecycle-churn.ts
@@ -1,0 +1,19 @@
+import type { TestContext } from '../types.ts'
+
+export const skip = process.platform === 'darwin'
+
+export const setup = async ({ Editor }: TestContext): Promise<void> => {
+  await Editor.closeAll()
+}
+
+export const run = async ({ WelcomePage }: TestContext): Promise<void> => {
+  await WelcomePage.show()
+  await WelcomePage.showFundamentals()
+  await WelcomePage.expandStepByIndex(0)
+  await WelcomePage.collapseStepByIndex(0)
+  await WelcomePage.hide()
+}
+
+export const teardown = async ({ Editor }: TestContext): Promise<void> => {
+  await Editor.closeAll()
+}

--- a/packages/e2e/src/welcome-walkthrough-lifecycle-churn.ts
+++ b/packages/e2e/src/welcome-walkthrough-lifecycle-churn.ts
@@ -9,8 +9,6 @@ export const setup = async ({ Editor }: TestContext): Promise<void> => {
 export const run = async ({ WelcomePage }: TestContext): Promise<void> => {
   await WelcomePage.show()
   await WelcomePage.showFundamentals()
-  await WelcomePage.expandStep('extensions')
-  await WelcomePage.expandStep('terminal')
   await WelcomePage.hide()
 }
 

--- a/packages/e2e/src/welcome-walkthrough-lifecycle-churn.ts
+++ b/packages/e2e/src/welcome-walkthrough-lifecycle-churn.ts
@@ -9,8 +9,8 @@ export const setup = async ({ Editor }: TestContext): Promise<void> => {
 export const run = async ({ WelcomePage }: TestContext): Promise<void> => {
   await WelcomePage.show()
   await WelcomePage.showFundamentals()
-  await WelcomePage.expandStepByIndex(0)
-  await WelcomePage.collapseStepByIndex(0)
+  await WelcomePage.expandStep('extensions')
+  await WelcomePage.expandStep('terminal')
   await WelcomePage.hide()
 }
 


### PR DESCRIPTION
Adds a focused skipped E2E scenario that repeatedly opens the Welcome editor, enters the fundamentals walkthrough, and closes the editor.

This gives the memory runner coverage for the getting-started editor and walkthrough lifecycle.