### PR TITLE
feature: add rename widget lifecycle memory e2e test

### DIFF
--- a/packages/e2e/src/rename-widget-lifecycle-churn.ts
+++ b/packages/e2e/src/rename-widget-lifecycle-churn.ts
@@ -1,0 +1,35 @@
+import type { TestContext } from '../types.ts'
+
+export const skip = 1
+
+const content = `:root {
+  --font-size: 10px;
+}`
+
+export const setup = async ({ Editor, Workspace }: TestContext): Promise<void> => {
+  await Workspace.setFiles([
+    {
+      content,
+      name: 'index.css',
+    },
+  ])
+  await Editor.closeAll()
+  await Editor.open('index.css')
+  await Editor.shouldHaveText(content)
+}
+
+export const run = async ({ Editor }: TestContext): Promise<void> => {
+  await Editor.click('--font-size')
+  await Editor.rename('--renamed')
+  await Editor.shouldHaveText(`:root {
+  --renamed: 10px;
+}`)
+  await Editor.click('--renamed')
+  await Editor.rename('--font-size')
+  await Editor.shouldHaveText(content)
+}
+
+export const teardown = async ({ Editor }: TestContext): Promise<void> => {
+  await Editor.save({ viaKeyBoard: true })
+  await Editor.closeAll()
+}


### PR DESCRIPTION
Adds a focused skipped E2E scenario that repeatedly opens the rename widget, applies a CSS symbol rename, and renames it back.

This gives the memory runner a deterministic lifecycle for rename input and CSS rename result state.