### PR TITLE
feature: add object URL count measure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,8 @@ jobs:
             args: --measure event-listeners --runs 17
           - name: event-listener-count
             args: --measure event-listener-count
+          - name: object-url-count
+            args: --measure object-url-count --runs 37 --restart-between --run-skipped-tests-anyway
           - name: dom-counters
             args: --measure dom-counters
           - name: detached-dom-node-count
@@ -282,6 +284,11 @@ jobs:
         with:
           name: vscode-memory-leak-finder-results-linux-event-listener-count
           path: ./vscode-memory-leak-finder-results-linux-event-listener-count
+      - uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: vscode-memory-leak-finder-results-linux-object-url-count
+          path: ./vscode-memory-leak-finder-results-linux-object-url-count
       - uses: actions/download-artifact@v8
         continue-on-error: true
         with:
@@ -571,6 +578,11 @@ jobs:
         continue-on-error: true
         with:
           name: vscode-memory-leak-finder-results-linux-event-listener-count
+      - name: Delete individual artifacts
+        uses: geekyeggo/delete-artifact@v6
+        continue-on-error: true
+        with:
+          name: vscode-memory-leak-finder-results-linux-object-url-count
       - name: Delete individual artifacts
         uses: geekyeggo/delete-artifact@v6
         continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ Compares V8 object shapes before and after a test. Results identify constructor,
 node packages/cli/bin/test.js --cwd packages/e2e --check-leaks --measure-after --measure object-shape-difference --only base
 ```
 
+### ObjectUrlCount
+
+Spies on `URL.createObjectURL` and `URL.revokeObjectURL` during a test and reports the number of calls plus the number of created object URLs that were not revoked.
+
+```sh
+node packages/cli/bin/test.js --cwd packages/e2e --check-leaks --measure-after --measure object-url-count --only base
+```
+
 ### MemoryCity
 
 Captures allocation-aware renderer and extension-host heap snapshots, computes

--- a/packages/build/test/CiWorkflow.test.ts
+++ b/packages/build/test/CiWorkflow.test.ts
@@ -46,3 +46,11 @@ test('ci runs promises-with-stack-trace in two shards and downloads both results
   expect(workflow).toContain('name: vscode-memory-leak-finder-results-linux-promises-with-stack-trace-shard-1')
   expect(workflow).toContain('name: vscode-memory-leak-finder-results-linux-promises-with-stack-trace-shard-2')
 })
+
+test('ci measures frontend object URLs for 37 runs and downloads the results for Pages', async () => {
+  const workflow = await readFile(getWorkflowPath(), 'utf8')
+
+  expect(workflow).toContain('args: --measure object-url-count --runs 37 --restart-between --run-skipped-tests-anyway')
+  expect(workflow).toContain('name: vscode-memory-leak-finder-results-linux-object-url-count')
+  expect(workflow).toContain('path: ./vscode-memory-leak-finder-results-linux-object-url-count')
+})

--- a/packages/charts/src/parts/Charts/Charts.ts
+++ b/packages/charts/src/parts/Charts/Charts.ts
@@ -32,6 +32,7 @@ export * as MutationObserverCount from '../CreateMutationObserverCountChart/Crea
 export * as NamedFunctionCount3 from '../CreateNamedFunctionCountChart3/CreateNamedFunctionCountChart3.ts'
 export * as NumberCount from '../CreateNumberCountChart/CreateNumberCountChart.ts'
 export * as ObjectCount from '../CreateObjectCountChart/CreateObjectCountChart.ts'
+export * as ObjectUrlCount from '../CreateObjectUrlCountChart/CreateObjectUrlCountChart.ts'
 export * as PaintEvents from '../CreatePaintEventsChart/CreatePaintEventsChart.ts'
 export * as PromiseCount from '../CreatePromiseCountChart/CreatePromiseCountChart.ts'
 export * as ProxyCount from '../CreateProxyCountChart/CreateProxyCountChart.ts'

--- a/packages/charts/src/parts/CreateObjectUrlCountChart/CreateObjectUrlCountChart.ts
+++ b/packages/charts/src/parts/CreateObjectUrlCountChart/CreateObjectUrlCountChart.ts
@@ -1,0 +1,14 @@
+import * as GetObjectUrlCountData from '../GetObjectUrlCountData/GetObjectUrlCountData.ts'
+
+export const name = 'object-url-count'
+
+export const getData = (basePath: string): Promise<any[]> => GetObjectUrlCountData.getObjectUrlCountData(basePath)
+
+export const createChart = (): { x: string; xLabel: string; y: string; yLabel: string } => {
+  return {
+    x: 'index',
+    xLabel: 'Frontend Test',
+    y: 'count',
+    yLabel: 'Active Object URLs',
+  }
+}

--- a/packages/charts/src/parts/GetObjectUrlCountData/GetObjectUrlCountData.ts
+++ b/packages/charts/src/parts/GetObjectUrlCountData/GetObjectUrlCountData.ts
@@ -1,0 +1,24 @@
+import { existsSync } from 'node:fs'
+import { readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import * as ReadJson from '../ReadJson/ReadJson.ts'
+
+export const getObjectUrlCountData = async (basePath: string): Promise<any[]> => {
+  const resultsPath = join(basePath, 'object-url-count')
+  if (!existsSync(resultsPath)) {
+    return []
+  }
+
+  const dirents = await readdir(resultsPath)
+  const allData: any[] = []
+  for (const [index, dirent] of dirents.toSorted().entries()) {
+    const absolutePath = join(resultsPath, dirent)
+    const data = await ReadJson.readJson(absolutePath)
+    allData.push({
+      count: data.objectUrlCount?.unreleased || 0,
+      index,
+      name: dirent,
+    })
+  }
+  return allData
+}

--- a/packages/charts/test/ObjectUrlCountChart.test.js
+++ b/packages/charts/test/ObjectUrlCountChart.test.js
@@ -1,0 +1,51 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, test } from '@jest/globals'
+import * as Charts from '../src/parts/Charts/Charts.ts'
+import * as CreateObjectUrlCountChart from '../src/parts/CreateObjectUrlCountChart/CreateObjectUrlCountChart.ts'
+import { getObjectUrlCountData } from '../src/parts/GetObjectUrlCountData/GetObjectUrlCountData.ts'
+
+test('getObjectUrlCountData returns active object URL counts per frontend test', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'object-url-count-data-'))
+  const basePath = join(workspaceRoot, '.vscode-memory-leak-finder-results')
+  const resultsPath = join(basePath, 'object-url-count')
+
+  await mkdir(resultsPath, { recursive: true })
+  await writeFile(
+    join(resultsPath, 'editor-open.json'),
+    JSON.stringify({
+      objectUrlCount: {
+        created: 5,
+        revoked: 2,
+        unreleased: 3,
+      },
+    }),
+  )
+
+  try {
+    const result = await getObjectUrlCountData(basePath)
+
+    expect(result).toEqual([
+      {
+        count: 3,
+        index: 0,
+        name: 'editor-open.json',
+      },
+    ])
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true })
+  }
+})
+
+test('createObjectUrlCountChart creates one homepage chart for active URLs', () => {
+  expect(Charts.ObjectUrlCount).toBe(CreateObjectUrlCountChart)
+  expect(CreateObjectUrlCountChart.name).toBe('object-url-count')
+  expect('multiple' in CreateObjectUrlCountChart).toBe(false)
+  expect(CreateObjectUrlCountChart.createChart()).toEqual({
+    x: 'index',
+    xLabel: 'Frontend Test',
+    y: 'count',
+    yLabel: 'Active Object URLs',
+  })
+})

--- a/packages/memory-leak-finder/src/parts/MeasureId/MeasureId.ts
+++ b/packages/memory-leak-finder/src/parts/MeasureId/MeasureId.ts
@@ -109,6 +109,7 @@ export const NamedFunctionDifferenceWithSourceMap = 'namedFunctionDifferenceWith
 export const NumberCount = 'numberCount'
 export const Numbers = 'numbers'
 export const ObjectCount = 'objectCount'
+export const ObjectUrlCount = 'objectUrlCount'
 export const ObjectShapeCount = 'objectShapeCount'
 export const ObjectShapeDifference = 'objectShapeDifference'
 export const Observers = 'observers'

--- a/packages/memory-leak-finder/src/parts/MeasureObjectUrlCount/MeasureObjectUrlCount.ts
+++ b/packages/memory-leak-finder/src/parts/MeasureObjectUrlCount/MeasureObjectUrlCount.ts
@@ -1,0 +1,48 @@
+import type { Session } from '../Session/Session.ts'
+import * as MeasureId from '../MeasureId/MeasureId.ts'
+import * as ObjectUrlTracker from '../ObjectUrlTracker/ObjectUrlTracker.ts'
+import type { ObjectUrlCounts } from '../ObjectUrlTracker/ObjectUrlTracker.ts'
+import * as TargetId from '../TargetId/TargetId.ts'
+
+export const id = MeasureId.ObjectUrlCount
+
+export const targets = [TargetId.Browser]
+
+export const create = (session: Session) => {
+  return [session]
+}
+
+const emptyCounts: ObjectUrlCounts = {
+  created: 0,
+  revoked: 0,
+  unreleased: 0,
+}
+
+export const start = async (session: Session): Promise<ObjectUrlCounts> => {
+  await ObjectUrlTracker.start(session)
+  return emptyCounts
+}
+
+export const stop = (session: Session): Promise<ObjectUrlCounts> => {
+  return ObjectUrlTracker.getCounts(session)
+}
+
+export const releaseResources = async (session: Session): Promise<void> => {
+  await ObjectUrlTracker.cleanup(session)
+}
+
+export const compare = (before: ObjectUrlCounts, after: ObjectUrlCounts): ObjectUrlCounts => {
+  return {
+    created: after.created - before.created,
+    revoked: after.revoked - before.revoked,
+    unreleased: after.unreleased - before.unreleased,
+  }
+}
+
+export const isLeak = (result: ObjectUrlCounts): boolean => {
+  return result.unreleased > 0
+}
+
+export const summary = ({ created, revoked, unreleased }: ObjectUrlCounts): string => {
+  return `Object URLs: ${created} created, ${revoked} revoked, ${unreleased} unreleased`
+}

--- a/packages/memory-leak-finder/src/parts/Measures/Measures.ts
+++ b/packages/memory-leak-finder/src/parts/Measures/Measures.ts
@@ -107,6 +107,7 @@ export * as MeasureNamedFunctionDifferenceWithSourceMap from '../MeasureNamedFun
 export * as MeasureNumberCount from '../MeasureNumberCount/MeasureNumberCount.ts'
 export * as MeasureNumbers from '../MeasureNumbers/MeasureNumbers.ts'
 export * as MeasureObjectCount from '../MeasureObjectCount/MeasureObjectCount.ts'
+export * as MeasureObjectUrlCount from '../MeasureObjectUrlCount/MeasureObjectUrlCount.ts'
 export * as MeasureObjectShapeCount from '../MeasureObjectShapeCount/MeasureObjectShapeCount.ts'
 export * as MeasureObjectShapeDifference from '../MeasureObjectShapeDifference/MeasureObjectShapeDifference.ts'
 export * as MeasureOffscreenCanvasCount from '../MeasureOffscreenCanvasCount/MeasureOffscreenCanvasCount.ts'

--- a/packages/memory-leak-finder/src/parts/ObjectUrlTracker/ObjectUrlTracker.ts
+++ b/packages/memory-leak-finder/src/parts/ObjectUrlTracker/ObjectUrlTracker.ts
@@ -1,0 +1,75 @@
+import type { Session } from '../Session/Session.ts'
+import { DevtoolsProtocolRuntime } from '../DevtoolsProtocol/DevtoolsProtocol.ts'
+
+export interface ObjectUrlCounts {
+  readonly created: number
+  readonly revoked: number
+  readonly unreleased: number
+}
+
+const startExpression = `(() => {
+  globalThis.___memoryLeakFinderObjectUrlTracker?.dispose()
+
+  const url = globalThis.URL
+  if (typeof url?.createObjectURL !== 'function' || typeof url?.revokeObjectURL !== 'function') {
+    throw new Error('object-url-count requires URL.createObjectURL and URL.revokeObjectURL')
+  }
+
+  const originalCreateObjectURL = url.createObjectURL
+  const originalRevokeObjectURL = url.revokeObjectURL
+  const activeUrls = new Set()
+  let created = 0
+  let revoked = 0
+
+  function createObjectURL(...args) {
+    created++
+    const objectUrl = originalCreateObjectURL.apply(this, args)
+    activeUrls.add(objectUrl)
+    return objectUrl
+  }
+
+  function revokeObjectURL(...args) {
+    revoked++
+    activeUrls.delete(args[0])
+    return originalRevokeObjectURL.apply(this, args)
+  }
+
+  url.createObjectURL = createObjectURL
+  url.revokeObjectURL = revokeObjectURL
+
+  globalThis.___memoryLeakFinderObjectUrlTracker = {
+    dispose() {
+      if (url.createObjectURL === createObjectURL) {
+        url.createObjectURL = originalCreateObjectURL
+      }
+      if (url.revokeObjectURL === revokeObjectURL) {
+        url.revokeObjectURL = originalRevokeObjectURL
+      }
+      delete globalThis.___memoryLeakFinderObjectUrlTracker
+    },
+    getCounts() {
+      return { created, revoked, unreleased: activeUrls.size }
+    },
+  }
+})()`
+
+const getCountsExpression = `(() => {
+  const tracker = globalThis.___memoryLeakFinderObjectUrlTracker
+  return tracker ? tracker.getCounts() : { created: 0, revoked: 0, unreleased: 0 }
+})()`
+
+const cleanupExpression = `(() => {
+  globalThis.___memoryLeakFinderObjectUrlTracker?.dispose()
+})()`
+
+export const start = async (session: Session): Promise<void> => {
+  await DevtoolsProtocolRuntime.evaluate(session, { expression: startExpression, returnByValue: true })
+}
+
+export const getCounts = async (session: Session): Promise<ObjectUrlCounts> => {
+  return DevtoolsProtocolRuntime.evaluate(session, { expression: getCountsExpression, returnByValue: true })
+}
+
+export const cleanup = async (session: Session): Promise<void> => {
+  await DevtoolsProtocolRuntime.evaluate(session, { expression: cleanupExpression, returnByValue: true })
+}

--- a/packages/memory-leak-finder/test/MeasureObjectUrlCount.test.ts
+++ b/packages/memory-leak-finder/test/MeasureObjectUrlCount.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const cleanup = jest.fn<(_session: unknown) => Promise<void>>()
+const getCounts = jest.fn<(_session: unknown) => Promise<{ created: number; revoked: number; unreleased: number }>>()
+const startTracking = jest.fn<(_session: unknown) => Promise<void>>()
+
+jest.unstable_mockModule('../src/parts/ObjectUrlTracker/ObjectUrlTracker.ts', () => ({
+  cleanup,
+  getCounts,
+  start: startTracking,
+}))
+
+const GetMeasure = await import('../src/parts/GetMeasure/GetMeasure.ts')
+const Measures = await import('../src/parts/Measures/Measures.ts')
+const MeasureObjectUrlCount = await import('../src/parts/MeasureObjectUrlCount/MeasureObjectUrlCount.ts')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('measures object URL lifecycle calls in the browser', async () => {
+  const session = {} as any
+  getCounts.mockResolvedValueOnce({ created: 3, revoked: 1, unreleased: 2 })
+
+  const args = MeasureObjectUrlCount.create(session) as [any]
+  const before = await MeasureObjectUrlCount.start(...args)
+  const after = await MeasureObjectUrlCount.stop(...args)
+  await MeasureObjectUrlCount.releaseResources(...args)
+  const result = MeasureObjectUrlCount.compare(before, after)
+
+  expect(MeasureObjectUrlCount.id).toBe('objectUrlCount')
+  expect(MeasureObjectUrlCount.targets).toEqual([1])
+  expect(startTracking).toHaveBeenCalledWith(session)
+  expect(cleanup).toHaveBeenCalledWith(session)
+  expect(result).toEqual({ created: 3, revoked: 1, unreleased: 2 })
+  expect(MeasureObjectUrlCount.isLeak(result)).toBe(true)
+  expect(MeasureObjectUrlCount.summary(result)).toBe('Object URLs: 3 created, 1 revoked, 2 unreleased')
+})
+
+test('does not report a leak when every created object URL is revoked', () => {
+  expect(MeasureObjectUrlCount.isLeak({ created: 2, revoked: 2, unreleased: 0 })).toBe(false)
+})
+
+test('resolves the public kebab-case measure id', () => {
+  expect(GetMeasure.getMeasure({ Measures }, 'object-url-count')).toBe(Measures.MeasureObjectUrlCount)
+})

--- a/packages/memory-leak-finder/test/ObjectUrlTracker.test.ts
+++ b/packages/memory-leak-finder/test/ObjectUrlTracker.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, expect, jest, test } from '@jest/globals'
+
+const evaluate = jest.fn(async (_session: unknown, options: { readonly expression: string }) => {
+  return new Function(`return ${options.expression}`)()
+})
+
+jest.unstable_mockModule('../src/parts/DevtoolsProtocol/DevtoolsProtocol.ts', () => ({
+  DevtoolsProtocolRuntime: { evaluate },
+}))
+
+const ObjectUrlTracker = await import('../src/parts/ObjectUrlTracker/ObjectUrlTracker.ts')
+
+const session = {} as any
+
+afterEach(async () => {
+  await ObjectUrlTracker.cleanup(session)
+  jest.clearAllMocks()
+})
+
+test('counts created, revoked, and unreleased object URLs', async () => {
+  const originalCreateObjectURL = URL.createObjectURL
+  const originalRevokeObjectURL = URL.revokeObjectURL
+  await ObjectUrlTracker.start(session)
+
+  const revokedUrl = URL.createObjectURL(new Blob(['revoked']))
+  const unreleasedUrl = URL.createObjectURL(new Blob(['unreleased']))
+  URL.revokeObjectURL(revokedUrl)
+
+  await expect(ObjectUrlTracker.getCounts(session)).resolves.toEqual({
+    created: 2,
+    revoked: 1,
+    unreleased: 1,
+  })
+
+  await ObjectUrlTracker.cleanup(session)
+  expect(URL.createObjectURL).toBe(originalCreateObjectURL)
+  expect(URL.revokeObjectURL).toBe(originalRevokeObjectURL)
+  URL.revokeObjectURL(unreleasedUrl)
+})
+
+test('does not count revocation of an object URL created before tracking as an unreleased URL', async () => {
+  const objectUrl = URL.createObjectURL(new Blob(['created before tracking']))
+  await ObjectUrlTracker.start(session)
+
+  URL.revokeObjectURL(objectUrl)
+
+  await expect(ObjectUrlTracker.getCounts(session)).resolves.toEqual({
+    created: 0,
+    revoked: 1,
+    unreleased: 0,
+  })
+})
+
+test('restarting tracking restores the previous spy before installing a new one', async () => {
+  const originalCreateObjectURL = URL.createObjectURL
+  await ObjectUrlTracker.start(session)
+  const firstSpy = URL.createObjectURL
+
+  await ObjectUrlTracker.start(session)
+
+  expect(URL.createObjectURL).not.toBe(firstSpy)
+  await ObjectUrlTracker.cleanup(session)
+  expect(URL.createObjectURL).toBe(originalCreateObjectURL)
+})


### PR DESCRIPTION
## Summary

- add a browser-only `object-url-count` measure
- spy on `URL.createObjectURL` and `URL.revokeObjectURL`, reporting created, revoked, and unreleased counts
- restore the original URL methods after measurement and avoid masking leaks with duplicate or pre-existing revocations
- run the frontend measure for 37 repetitions in CI and merge its artifact into the Pages input
- render one `Active Object URLs` homepage chart from the final unreleased count for each frontend test
- register and document the public measure

Related: microsoft/vscode#332565

## Testing

- `npm run type-check`
- `npm --prefix packages/memory-leak-finder test -- --runInBand` (100 suites and 327 tests passed; one suite skipped)
- object URL chart tests (2 passed)
- CI workflow tests (5 passed)
- targeted Prettier checks