### PR TITLE
feature: add large editor replacement lifecycle e2e test

### DIFF
--- a/packages/e2e/src/editor-large-replacement-lifecycle-churn.ts
+++ b/packages/e2e/src/editor-large-replacement-lifecycle-churn.ts
@@ -1,0 +1,32 @@
+import type { TestContext } from '../types.ts'
+
+export const skip = 1
+
+const fileCount = 40
+const largeText = `${'A'.repeat(8 * 1024)}\n`
+let nextFile = 0
+
+export const setup = async ({ Editor, Workspace }: TestContext): Promise<void> => {
+  await Workspace.setFiles(
+    Array.from({ length: fileCount }, (_, index) => ({
+      content: largeText,
+      name: `large-edit-buffer-${index + 1}.txt`,
+    })),
+  )
+  await Editor.closeAll()
+}
+
+export const run = async ({ Editor }: TestContext): Promise<void> => {
+  const fileName = `large-edit-buffer-${(nextFile++ % fileCount) + 1}.txt`
+  try {
+    await Editor.open(fileName)
+    await Editor.focus()
+    await Editor.replaceActiveLineAndSave({ replacement: 'x' })
+  } finally {
+    await Editor.closeAll()
+  }
+}
+
+export const teardown = async ({ Editor }: TestContext): Promise<void> => {
+  await Editor.closeAll()
+}

--- a/packages/e2e/types/pageobject-api.d.ts
+++ b/packages/e2e/types/pageobject-api.d.ts
@@ -257,6 +257,7 @@ export interface Editor {
   rename(newText: any): Promise<void>
   renameCancel(newText: any): Promise<void>
   renameWithPreview(newText: any): Promise<void>
+  replaceActiveLineAndSave(options: { replacement: string }): Promise<void>
   replaceText(options: any): Promise<void>
   save(options: any): Promise<void>
   saveAll(): Promise<void>

--- a/packages/page-object/src/parts/Editor/Editor.ts
+++ b/packages/page-object/src/parts/Editor/Editor.ts
@@ -1013,6 +1013,22 @@ export const create = ({ electronApp, expect, ideVersion, page, platform, VError
         throw new VError(error, `Failed to replace text ${newText}`)
       }
     },
+    async replaceActiveLineAndSave({ replacement }: { replacement: string }) {
+      try {
+        const modifier = IsMacos.isMacos(platform) ? 'Meta' : 'Control'
+        const dirtyTabs = page.locator('.tab.dirty')
+        const editContext = page.locator('.editor-instance .native-edit-context')
+        await editContext.focus()
+        await page.keyboard.press(`${modifier}+A`)
+        await page.keyboard.type(replacement)
+        await expect(dirtyTabs).toHaveCount(1, { timeout: 10_000 })
+        await editContext.focus()
+        await page.keyboard.press(`${modifier}+S`)
+        await expect(dirtyTabs).toHaveCount(0, { timeout: 10_000 })
+      } catch (error) {
+        throw new VError(error, `Failed to replace and save the active editor line`)
+      }
+    },
     async save(options?: { viaKeyBoard: boolean }) {
       try {
         if (options?.viaKeyBoard) {


### PR DESCRIPTION

<img width="1400" height="300" alt="editor-large-replacement-lifecycle-churn" src="https://github.com/user-attachments/assets/5655f9ab-481f-42fc-912b-c3fdc7086550" />
## Details

- create forty 8 KiB single-line text files for an on-demand lifecycle scenario
- open a fresh file on every cycle, replace its complete contents through the real editor UI, save it, and close the editor
- add a focused page-object helper for keyboard replacement and save without waiting for global renderer idleness

## Memory measurement

A 37-cycle `named-function-count3` run found one retained `DisposedModelInfo` and one retained `ResourceEditStackSnapshot` per cycle. Both grew by 37, from 3 objects before the run to 40 after it. Editor selections also grew by 37, while text-editor pane selections grew by 74.

## Validation

- one-run e2e smoke test under `xvfb-run`
- 37-cycle `named-function-count3` leak check under `xvfb-run`
- TypeScript project type check
- Prettier and diff checks