### PR TITLE
fix: track object URLs for renderer lifetime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
           - name: event-listener-count
             args: --measure event-listener-count
           - name: object-url-count
-            args: --measure object-url-count --runs 37 --restart-between --run-skipped-tests-anyway
+            args: --measure object-url-count --runs 37 --run-skipped-tests-anyway
           - name: dom-counters
             args: --measure dom-counters
           - name: detached-dom-node-count

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ node packages/cli/bin/test.js --cwd packages/e2e --check-leaks --measure-after -
 
 ### ObjectUrlCount
 
-Spies on `URL.createObjectURL` and `URL.revokeObjectURL` during a test and reports the number of calls plus the number of created object URLs that were not revoked.
+Spies on `URL.createObjectURL` and `URL.revokeObjectURL` from renderer startup and reports cumulative call counts plus the number of created object URLs that are still active after each test.
 
 ```sh
 node packages/cli/bin/test.js --cwd packages/e2e --check-leaks --measure-after --measure object-url-count --only base

--- a/packages/build/test/CiWorkflow.test.ts
+++ b/packages/build/test/CiWorkflow.test.ts
@@ -50,7 +50,8 @@ test('ci runs promises-with-stack-trace in two shards and downloads both results
 test('ci measures frontend object URLs for 37 runs and downloads the results for Pages', async () => {
   const workflow = await readFile(getWorkflowPath(), 'utf8')
 
-  expect(workflow).toContain('args: --measure object-url-count --runs 37 --restart-between --run-skipped-tests-anyway')
+  expect(workflow).toContain('args: --measure object-url-count --runs 37 --run-skipped-tests-anyway')
+  expect(workflow).not.toContain('args: --measure object-url-count --runs 37 --restart-between')
   expect(workflow).toContain('name: vscode-memory-leak-finder-results-linux-object-url-count')
   expect(workflow).toContain('path: ./vscode-memory-leak-finder-results-linux-object-url-count')
 })

--- a/packages/initialization-worker/src/parts/ConnectDevtools/ConnectDevtools.ts
+++ b/packages/initialization-worker/src/parts/ConnectDevtools/ConnectDevtools.ts
@@ -1,13 +1,22 @@
 import * as DebuggerCreateIpcConnection from '../DebuggerCreateIpcConnection/DebuggerCreateIpcConnection.ts'
 import * as DebuggerCreateRpcConnection from '../DebuggerCreateRpcConnection/DebuggerCreateRpcConnection.ts'
 import { DevtoolsProtocolRuntime } from '../DevtoolsProtocol/DevtoolsProtocol.ts'
+import { objectUrlTrackerScript } from '../ObjectUrlTrackerScript/ObjectUrlTrackerScript.ts'
 import { waitForSession } from '../WaitForSession/WaitForSession.ts'
 
-export const connectDevtools = async (devtoolsWebSocketUrl: string, attachedToPageTimeout: number): Promise<any> => {
+const isObjectUrlCountMeasure = (measureId: string): boolean => {
+  return measureId === 'objectUrlCount' || measureId === 'objecturlcount' || measureId === 'object-url-count'
+}
+
+export const connectDevtools = async (devtoolsWebSocketUrl: string, attachedToPageTimeout: number, measureId: string): Promise<any> => {
   const browserIpc = await DebuggerCreateIpcConnection.createConnection(devtoolsWebSocketUrl)
   const browserRpc = DebuggerCreateRpcConnection.createRpc(browserIpc)
   const { sessionId, sessionRpc, targetId } = await waitForSession(browserRpc, attachedToPageTimeout)
+  const objectUrlTrackerPromise = isObjectUrlCountMeasure(measureId)
+    ? DevtoolsProtocolRuntime.evaluate(sessionRpc, { expression: objectUrlTrackerScript, returnByValue: true })
+    : undefined
   await DevtoolsProtocolRuntime.runIfWaitingForDebugger(sessionRpc)
+  await objectUrlTrackerPromise
   return {
     async dispose() {
       await browserRpc.dispose()

--- a/packages/initialization-worker/src/parts/ObjectUrlTrackerScript/ObjectUrlTrackerScript.ts
+++ b/packages/initialization-worker/src/parts/ObjectUrlTrackerScript/ObjectUrlTrackerScript.ts
@@ -1,20 +1,11 @@
-import type { Session } from '../Session/Session.ts'
-import { DevtoolsProtocolRuntime } from '../DevtoolsProtocol/DevtoolsProtocol.ts'
-
-export interface ObjectUrlCounts {
-  readonly created: number
-  readonly revoked: number
-  readonly unreleased: number
-}
-
-const startExpression = `(() => {
+export const objectUrlTrackerScript = `(() => {
   if (globalThis.___memoryLeakFinderObjectUrlTracker) {
     return
   }
 
   const url = globalThis.URL
   if (typeof url?.createObjectURL !== 'function' || typeof url?.revokeObjectURL !== 'function') {
-    throw new Error('object-url-count requires URL.createObjectURL and URL.revokeObjectURL')
+    return
   }
 
   const originalCreateObjectURL = url.createObjectURL
@@ -54,24 +45,3 @@ const startExpression = `(() => {
     },
   }
 })()`
-
-const getCountsExpression = `(() => {
-  const tracker = globalThis.___memoryLeakFinderObjectUrlTracker
-  return tracker ? tracker.getCounts() : { created: 0, revoked: 0, unreleased: 0 }
-})()`
-
-const cleanupExpression = `(() => {
-  globalThis.___memoryLeakFinderObjectUrlTracker?.dispose()
-})()`
-
-export const start = async (session: Session): Promise<void> => {
-  await DevtoolsProtocolRuntime.evaluate(session, { expression: startExpression, returnByValue: true })
-}
-
-export const getCounts = async (session: Session): Promise<ObjectUrlCounts> => {
-  return DevtoolsProtocolRuntime.evaluate(session, { expression: getCountsExpression, returnByValue: true })
-}
-
-export const cleanup = async (session: Session): Promise<void> => {
-  await DevtoolsProtocolRuntime.evaluate(session, { expression: cleanupExpression, returnByValue: true })
-}

--- a/packages/initialization-worker/src/parts/PrepareBoth/PrepareBoth.ts
+++ b/packages/initialization-worker/src/parts/PrepareBoth/PrepareBoth.ts
@@ -42,7 +42,7 @@ export const prepareBoth = async (
 
   const devtoolsWebSocketUrl = await devtoolsWebSocketUrlPromise
 
-  const connectDevtoolsPromise = connectDevtools(devtoolsWebSocketUrl, attachedToPageTimeout)
+  const connectDevtoolsPromise = connectDevtools(devtoolsWebSocketUrl, attachedToPageTimeout, measureId)
 
   if (headlessMode) {
     // TODO

--- a/packages/initialization-worker/test/ConnectDevtools.test.ts
+++ b/packages/initialization-worker/test/ConnectDevtools.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const calls: string[] = []
+let resolveEvaluate: (() => void) | undefined
+const evaluate = jest.fn((_rpc: unknown, options: { readonly expression: string }) => {
+  calls.push('evaluate')
+  expect(options.expression).toContain('___memoryLeakFinderObjectUrlTracker')
+  return new Promise<void>((resolve) => {
+    resolveEvaluate = resolve
+  })
+})
+const runIfWaitingForDebugger = jest.fn(async () => {
+  calls.push('resume')
+  resolveEvaluate?.()
+})
+
+jest.unstable_mockModule('../src/parts/DebuggerCreateIpcConnection/DebuggerCreateIpcConnection.ts', () => ({
+  createConnection: async () => ({}),
+}))
+
+jest.unstable_mockModule('../src/parts/DebuggerCreateRpcConnection/DebuggerCreateRpcConnection.ts', () => ({
+  createRpc: () => ({
+    dispose: async () => {},
+  }),
+}))
+
+jest.unstable_mockModule('../src/parts/WaitForSession/WaitForSession.ts', () => ({
+  waitForSession: async () => ({
+    sessionId: 'session-id',
+    sessionRpc: {},
+    targetId: 'target-id',
+  }),
+}))
+
+jest.unstable_mockModule('../src/parts/DevtoolsProtocol/DevtoolsProtocol.ts', () => ({
+  DevtoolsProtocolRuntime: { evaluate, runIfWaitingForDebugger },
+}))
+
+const { connectDevtools } = await import('../src/parts/ConnectDevtools/ConnectDevtools.ts')
+
+beforeEach(() => {
+  calls.length = 0
+  resolveEvaluate = undefined
+  jest.clearAllMocks()
+})
+
+test.each(['objectUrlCount', 'objecturlcount', 'object-url-count'])(
+  'installs %s tracking before the renderer resumes',
+  async (measureId) => {
+    await connectDevtools('ws://devtools', 1000, measureId)
+
+    expect(calls).toEqual(['evaluate', 'resume'])
+  },
+)
+
+test('does not install object URL tracking for other measures', async () => {
+  await connectDevtools('ws://devtools', 1000, 'array-count')
+
+  expect(evaluate).not.toHaveBeenCalled()
+  expect(calls).toEqual(['resume'])
+})

--- a/packages/initialization-worker/test/ObjectUrlTrackerScript.test.ts
+++ b/packages/initialization-worker/test/ObjectUrlTrackerScript.test.ts
@@ -1,0 +1,39 @@
+import { runInNewContext } from 'node:vm'
+import { expect, test } from '@jest/globals'
+import { objectUrlTrackerScript } from '../src/parts/ObjectUrlTrackerScript/ObjectUrlTrackerScript.ts'
+
+test('tracks object URLs for the lifetime of a renderer document', () => {
+  let nextId = 0
+  const context: any = {
+    URL: {
+      createObjectURL: () => `blob:test-${++nextId}`,
+      revokeObjectURL: () => {},
+    },
+  }
+
+  runInNewContext(objectUrlTrackerScript, context)
+  const revoked = context.URL.createObjectURL({})
+  context.URL.createObjectURL({})
+  context.URL.revokeObjectURL(revoked)
+
+  expect(context.___memoryLeakFinderObjectUrlTracker.getCounts()).toEqual({
+    created: 2,
+    revoked: 1,
+    unreleased: 1,
+  })
+})
+
+test('does not reset an existing process-lifetime tracker', () => {
+  const context: any = {
+    URL: {
+      createObjectURL: () => 'blob:test',
+      revokeObjectURL: () => {},
+    },
+  }
+
+  runInNewContext(objectUrlTrackerScript, context)
+  context.URL.createObjectURL({})
+  runInNewContext(objectUrlTrackerScript, context)
+
+  expect(context.___memoryLeakFinderObjectUrlTracker.getCounts().created).toBe(1)
+})

--- a/packages/initialization-worker/test/PrepareBoth.test.ts
+++ b/packages/initialization-worker/test/PrepareBoth.test.ts
@@ -1,5 +1,11 @@
 import { expect, jest, test } from '@jest/globals'
 
+const connectDevtools = jest.fn(async (_devtoolsWebSocketUrl: string, _attachedToPageTimeout: number, _measureId: string) => ({
+  dispose: async () => {},
+  sessionId: 'session-id',
+  targetId: 'target-id',
+}))
+
 jest.unstable_mockModule('../src/parts/WaitForDebuggerListening/WaitForDebuggerListening.ts', () => {
   return {
     WaitForDebuggerListening: {},
@@ -39,11 +45,7 @@ jest.unstable_mockModule('../src/parts/ConnectElectron/ConnectElectron.ts', () =
 
 jest.unstable_mockModule('../src/parts/ConnectDevtools/ConnectDevtools.ts', () => {
   return {
-    connectDevtools: async () => ({
-      dispose: async () => {},
-      sessionId: 'session-id',
-      targetId: 'target-id',
-    }),
+    connectDevtools,
   }
 })
 
@@ -79,4 +81,5 @@ test('prepareBoth returns real electron process id from runtime evaluation', asy
   )
 
   expect(result.pid).toBe(9876)
+  expect(connectDevtools).toHaveBeenCalledWith('ws://devtools', 1000, 'cpuPerformanceCountersFromStart')
 })

--- a/packages/memory-leak-finder/src/parts/MeasureObjectUrlCount/MeasureObjectUrlCount.ts
+++ b/packages/memory-leak-finder/src/parts/MeasureObjectUrlCount/MeasureObjectUrlCount.ts
@@ -27,9 +27,7 @@ export const stop = (session: Session): Promise<ObjectUrlCounts> => {
   return ObjectUrlTracker.getCounts(session)
 }
 
-export const releaseResources = async (session: Session): Promise<void> => {
-  await ObjectUrlTracker.cleanup(session)
-}
+export const releaseResources = async (_session: Session): Promise<void> => {}
 
 export const compare = (before: ObjectUrlCounts, after: ObjectUrlCounts): ObjectUrlCounts => {
   return {

--- a/packages/memory-leak-finder/test/MeasureObjectUrlCount.test.ts
+++ b/packages/memory-leak-finder/test/MeasureObjectUrlCount.test.ts
@@ -31,10 +31,20 @@ test('measures object URL lifecycle calls in the browser', async () => {
   expect(MeasureObjectUrlCount.id).toBe('objectUrlCount')
   expect(MeasureObjectUrlCount.targets).toEqual([1])
   expect(startTracking).toHaveBeenCalledWith(session)
-  expect(cleanup).toHaveBeenCalledWith(session)
+  expect(cleanup).not.toHaveBeenCalled()
   expect(result).toEqual({ created: 3, revoked: 1, unreleased: 2 })
   expect(MeasureObjectUrlCount.isLeak(result)).toBe(true)
   expect(MeasureObjectUrlCount.summary(result)).toBe('Object URLs: 3 created, 1 revoked, 2 unreleased')
+})
+
+test('uses an empty baseline so results remain cumulative from renderer startup', async () => {
+  const session = {} as any
+
+  await expect(MeasureObjectUrlCount.start(session)).resolves.toEqual({
+    created: 0,
+    revoked: 0,
+    unreleased: 0,
+  })
 })
 
 test('does not report a leak when every created object URL is revoked', () => {

--- a/packages/memory-leak-finder/test/ObjectUrlTracker.test.ts
+++ b/packages/memory-leak-finder/test/ObjectUrlTracker.test.ts
@@ -51,14 +51,20 @@ test('does not count revocation of an object URL created before tracking as an u
   })
 })
 
-test('restarting tracking restores the previous spy before installing a new one', async () => {
+test('starting tracking again preserves the process-lifetime tracker', async () => {
   const originalCreateObjectURL = URL.createObjectURL
   await ObjectUrlTracker.start(session)
   const firstSpy = URL.createObjectURL
+  URL.createObjectURL(new Blob(['first']))
 
   await ObjectUrlTracker.start(session)
 
-  expect(URL.createObjectURL).not.toBe(firstSpy)
+  expect(URL.createObjectURL).toBe(firstSpy)
+  await expect(ObjectUrlTracker.getCounts(session)).resolves.toEqual({
+    created: 1,
+    revoked: 0,
+    unreleased: 1,
+  })
   await ObjectUrlTracker.cleanup(session)
   expect(URL.createObjectURL).toBe(originalCreateObjectURL)
 })


### PR DESCRIPTION
## Summary

- install object URL tracking while the renderer is paused at startup
- preserve the tracker across frontend tests so chart samples are cumulative
- remove restart-between from the object-url-count CI measure
- document and test the process-lifetime behavior

## Validation

- npm run type-check
- initialization-worker: 53 tests passed
- memory-leak-finder: 340 tests passed, 4 skipped
- build: 99 tests passed
- isolated Electron run: active object URLs increased from 8 after the first test to 16 after the second test in the same process