### PR TITLE
fix: collect garbage before counting promises

### DIFF
--- a/packages/memory-leak-finder/src/parts/MeasurePromiseCount/MeasurePromiseCount.ts
+++ b/packages/memory-leak-finder/src/parts/MeasurePromiseCount/MeasurePromiseCount.ts
@@ -1,5 +1,6 @@
 import type { Session } from '../Session/Session.ts'
 import * as CompareCount from '../CompareCount/CompareCount.ts'
+import * as ForceGarbageCollection from '../ForceGarbageCollection/ForceGarbageCollection.ts'
 import * as GetPromiseCount from '../GetPromiseCount/GetPromiseCount.ts'
 import * as IsLeakCount from '../IsLeakCount/IsLeakCount.ts'
 import * as MeasureId from '../MeasureId/MeasureId.ts'
@@ -17,12 +18,14 @@ export const create = (session: Session) => {
 }
 
 export const start = async (session: Session, objectGroup: string) => {
+  await ForceGarbageCollection.forceGarbageCollection(session)
   const result = await GetPromiseCount.getPromiseCount(session, objectGroup)
   await ReleaseObjectGroup.releaseObjectGroup(session, objectGroup)
   return result
 }
 
 export const stop = async (session: Session, objectGroup: string) => {
+  await ForceGarbageCollection.forceGarbageCollection(session)
   const result = await GetPromiseCount.getPromiseCount(session, objectGroup)
   await ReleaseObjectGroup.releaseObjectGroup(session, objectGroup)
   return result

--- a/packages/memory-leak-finder/test/MeasurePromiseCount.test.ts
+++ b/packages/memory-leak-finder/test/MeasurePromiseCount.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const mockForceGarbageCollection = jest.fn<(...args: any[]) => Promise<void>>()
+const mockGetPromiseCount = jest.fn<(...args: any[]) => Promise<number>>()
+const mockReleaseObjectGroup = jest.fn<(...args: any[]) => Promise<void>>()
+
+jest.unstable_mockModule('../src/parts/ForceGarbageCollection/ForceGarbageCollection.ts', () => ({
+  forceGarbageCollection: mockForceGarbageCollection,
+}))
+jest.unstable_mockModule('../src/parts/GetPromiseCount/GetPromiseCount.ts', () => ({
+  getPromiseCount: mockGetPromiseCount,
+}))
+jest.unstable_mockModule('../src/parts/ReleaseObjectGroup/ReleaseObjectGroup.ts', () => ({
+  releaseObjectGroup: mockReleaseObjectGroup,
+}))
+
+const MeasurePromiseCount = await import('../src/parts/MeasurePromiseCount/MeasurePromiseCount.ts')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockForceGarbageCollection.mockResolvedValue()
+  mockGetPromiseCount.mockResolvedValue(123)
+  mockReleaseObjectGroup.mockResolvedValue()
+})
+
+test.each(['start', 'stop'] as const)('%s counts promises after garbage collection', async (method) => {
+  const calls: string[] = []
+  const session = {}
+  mockForceGarbageCollection.mockImplementation(async () => {
+    calls.push('gc')
+  })
+  mockGetPromiseCount.mockImplementation(async () => {
+    calls.push('count')
+    return 123
+  })
+  mockReleaseObjectGroup.mockImplementation(async () => {
+    calls.push('release')
+  })
+
+  await expect(MeasurePromiseCount[method](session as any, 'promises')).resolves.toBe(123)
+
+  expect(calls).toEqual(['gc', 'count', 'release'])
+  expect(mockForceGarbageCollection).toHaveBeenCalledWith(session)
+  expect(mockGetPromiseCount).toHaveBeenCalledWith(session, 'promises')
+  expect(mockReleaseObjectGroup).toHaveBeenCalledWith(session, 'promises')
+})


### PR DESCRIPTION
## Summary

- force renderer garbage collection before promise-count snapshots
- exclude unreachable promises that V8 has not collected yet from leak results
- cover both the start and stop measurement paths with an ordering regression test

## Details

The large-repository test appeared to retain roughly 800 promises after creating 2,000 files. Allocation-stack diagnostics showed only one newly retained promise, while forcing garbage collection immediately before each snapshot made the count stable. The extra promises were therefore unreachable objects awaiting GC rather than a VS Code leak.

In an exact CI-mode replay, the affected final measurements changed from large plateaus to stable counts:

- large repository: `788 → 834` before, `292 → 292` after
- large file: `1139 → 704` before, `308 → 308` after
- twenty editors: `1162 → 723` before, `327 → 327` after

## Validation

- `npm test -- MeasurePromiseCount.test.ts --runInBand` (2 tests passed)
- full memory-leak-finder test suite (342 tests passed, 4 skipped)
- TypeScript check
- Prettier check
- full CI-mode memory replay
