### PR TITLE
fix: release map and set size measurement handles

### DIFF
--- a/packages/memory-leak-finder/src/parts/GetMapSize/GetMapSize.ts
+++ b/packages/memory-leak-finder/src/parts/GetMapSize/GetMapSize.ts
@@ -1,17 +1,23 @@
 import type { Session } from '../Session/Session.ts'
 import { DevtoolsProtocolRuntime } from '../DevtoolsProtocol/DevtoolsProtocol.ts'
 import * as PrototypeExpression from '../PrototypeExpression/PrototypeExpression.ts'
+import * as ObjectGroupId from '../ObjectGroupId/ObjectGroupId.ts'
+import * as ReleaseObjectGroup from '../ReleaseObjectGroup/ReleaseObjectGroup.ts'
 
 export const getMapSize = async (session: Session) => {
-  const prototypeDescriptor = await DevtoolsProtocolRuntime.evaluate(session, {
-    expression: PrototypeExpression.Map,
-    returnByValue: false,
-  })
-  const objects = await DevtoolsProtocolRuntime.queryObjects(session, {
-    prototypeObjectId: prototypeDescriptor.objectId,
-  })
-  const fnResult1 = await DevtoolsProtocolRuntime.callFunctionOn(session, {
-    functionDeclaration: `function(){
+  const objectGroup = ObjectGroupId.create()
+  try {
+    const prototypeDescriptor = await DevtoolsProtocolRuntime.evaluate(session, {
+      expression: PrototypeExpression.Map,
+      objectGroup,
+      returnByValue: false,
+    })
+    const objects = await DevtoolsProtocolRuntime.queryObjects(session, {
+      objectGroup,
+      prototypeObjectId: prototypeDescriptor.objectId,
+    })
+    const fnResult1 = await DevtoolsProtocolRuntime.callFunctionOn(session, {
+      functionDeclaration: `function(){
   const objects = this
   let total = 0
   for(const object of objects){
@@ -19,8 +25,11 @@ export const getMapSize = async (session: Session) => {
   }
   return total
 }`,
-    objectId: objects.objects.objectId,
-    returnByValue: true,
-  })
-  return fnResult1
+      objectId: objects.objects.objectId,
+      returnByValue: true,
+    })
+    return fnResult1
+  } finally {
+    await ReleaseObjectGroup.releaseObjectGroup(session, objectGroup)
+  }
 }

--- a/packages/memory-leak-finder/src/parts/GetSetSize/GetSetSize.ts
+++ b/packages/memory-leak-finder/src/parts/GetSetSize/GetSetSize.ts
@@ -1,17 +1,23 @@
 import type { Session } from '../Session/Session.ts'
 import { DevtoolsProtocolRuntime } from '../DevtoolsProtocol/DevtoolsProtocol.ts'
 import * as PrototypeExpression from '../PrototypeExpression/PrototypeExpression.ts'
+import * as ObjectGroupId from '../ObjectGroupId/ObjectGroupId.ts'
+import * as ReleaseObjectGroup from '../ReleaseObjectGroup/ReleaseObjectGroup.ts'
 
 export const getSetSize = async (session: Session) => {
-  const prototypeDescriptor = await DevtoolsProtocolRuntime.evaluate(session, {
-    expression: PrototypeExpression.Set,
-    returnByValue: false,
-  })
-  const objects = await DevtoolsProtocolRuntime.queryObjects(session, {
-    prototypeObjectId: prototypeDescriptor.objectId,
-  })
-  const fnResult1 = await DevtoolsProtocolRuntime.callFunctionOn(session, {
-    functionDeclaration: `function(){
+  const objectGroup = ObjectGroupId.create()
+  try {
+    const prototypeDescriptor = await DevtoolsProtocolRuntime.evaluate(session, {
+      expression: PrototypeExpression.Set,
+      objectGroup,
+      returnByValue: false,
+    })
+    const objects = await DevtoolsProtocolRuntime.queryObjects(session, {
+      objectGroup,
+      prototypeObjectId: prototypeDescriptor.objectId,
+    })
+    const fnResult1 = await DevtoolsProtocolRuntime.callFunctionOn(session, {
+      functionDeclaration: `function(){
   const objects = this
   let total = 0
   for(const object of objects){
@@ -19,8 +25,11 @@ export const getSetSize = async (session: Session) => {
   }
   return total
 }`,
-    objectId: objects.objects.objectId,
-    returnByValue: true,
-  })
-  return fnResult1
+      objectId: objects.objects.objectId,
+      returnByValue: true,
+    })
+    return fnResult1
+  } finally {
+    await ReleaseObjectGroup.releaseObjectGroup(session, objectGroup)
+  }
 }

--- a/packages/memory-leak-finder/test/ContainerSizes.test.ts
+++ b/packages/memory-leak-finder/test/ContainerSizes.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const evaluate = jest.fn<(...args: any[]) => Promise<any>>()
+const queryObjects = jest.fn<(...args: any[]) => Promise<any>>()
+const callFunctionOn = jest.fn<(...args: any[]) => Promise<any>>()
+const releaseObjectGroup = jest.fn<(...args: any[]) => Promise<void>>()
+
+jest.unstable_mockModule('../src/parts/DevtoolsProtocol/DevtoolsProtocol.ts', () => ({
+  DevtoolsProtocolRuntime: { evaluate, queryObjects, callFunctionOn, releaseObjectGroup },
+}))
+
+beforeEach(() => {
+  jest.resetModules()
+  jest.resetAllMocks()
+  evaluate.mockResolvedValue({ objectId: 'prototype' })
+  queryObjects.mockResolvedValue({ objects: { objectId: 'containers' } })
+  callFunctionOn.mockResolvedValue(17)
+  releaseObjectGroup.mockResolvedValue()
+})
+
+for (const kind of ['Map', 'Set']) {
+  const measure = async (session: any) => {
+    if (kind === 'Map') {
+      return (await import('../src/parts/GetMapSize/GetMapSize.ts')).getMapSize(session)
+    }
+    return (await import('../src/parts/GetSetSize/GetSetSize.ts')).getSetSize(session)
+  }
+
+  test(`${kind} size releases queried containers before returning`, async () => {
+    const session = {}
+    await expect(measure(session)).resolves.toBe(17)
+
+    const group = evaluate.mock.calls[0][1].objectGroup
+    expect(group).toEqual(expect.any(String))
+    expect(queryObjects).toHaveBeenCalledWith(session, { objectGroup: group, prototypeObjectId: 'prototype' })
+    expect(releaseObjectGroup).toHaveBeenCalledWith(session, { objectGroup: group })
+    expect(callFunctionOn.mock.invocationCallOrder[0]).toBeLessThan(releaseObjectGroup.mock.invocationCallOrder[0])
+  })
+
+  for (const failingCommand of [evaluate, queryObjects, callFunctionOn]) {
+    test(`${kind} size releases its group when ${[evaluate, queryObjects, callFunctionOn].indexOf(failingCommand)} fails`, async () => {
+      const failure = new Error('measurement failed')
+      failingCommand.mockRejectedValue(failure)
+
+      await expect(measure({})).rejects.toBe(failure)
+      expect(releaseObjectGroup).toHaveBeenCalledTimes(1)
+    })
+  }
+}

--- a/packages/memory-leak-finder/test/ContainerSizesGc.test.ts
+++ b/packages/memory-leak-finder/test/ContainerSizesGc.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@jest/globals'
+import { execFile } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+const fixturePath = fileURLToPath(new URL('./fixtures/container-size-gc.mjs', import.meta.url))
+
+test.each(['Map', 'Set'])(
+  '%s size does not keep measured containers alive',
+  async (kind) => {
+    const { stdout } = await execFileAsync(process.execPath, [fixturePath, kind], { timeout: 10_000 })
+    expect(stdout.trim()).toBe('0')
+  },
+  15_000,
+)

--- a/packages/memory-leak-finder/test/ContainerSizesGc.test.ts
+++ b/packages/memory-leak-finder/test/ContainerSizesGc.test.ts
@@ -9,7 +9,10 @@ const fixturePath = fileURLToPath(new URL('./fixtures/container-size-gc.mjs', im
 test.each(['Map', 'Set'])(
   '%s size does not keep measured containers alive',
   async (kind) => {
-    const { stdout } = await execFileAsync(process.execPath, [fixturePath, kind], { timeout: 10_000 })
+    const { stdout } = await execFileAsync(process.execPath, [fixturePath, kind], {
+      env: { ...process.env, FORCE_COLOR: '1' },
+      timeout: 10_000,
+    })
     expect(stdout.trim()).toBe('0')
   },
   15_000,

--- a/packages/memory-leak-finder/test/fixtures/container-size-gc.mjs
+++ b/packages/memory-leak-finder/test/fixtures/container-size-gc.mjs
@@ -1,0 +1,29 @@
+import { Session } from 'node:inspector/promises'
+
+const kind = process.argv[2]
+const getter = await import(`../../src/parts/Get${kind}Size/Get${kind}Size.ts`)
+const inspector = new Session()
+inspector.connect()
+const rpc = {
+  /** @param {string} method @param {object} options */
+  async invoke(method, options) {
+    return { result: await inspector.post(method, options) }
+  },
+  dispose() {},
+}
+/** @param {string} expression */
+const evaluate = async (expression) => inspector.post('Runtime.evaluate', { expression, returnByValue: true })
+try {
+  await evaluate(
+    `globalThis.containers = Array.from({length: 10}, () => new ${kind}()); globalThis.references = containers.map(x => new WeakRef(x)); undefined`,
+  )
+  await getter[`get${kind}Size`](rpc)
+  await evaluate('globalThis.containers = undefined')
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  await inspector.post('HeapProfiler.collectGarbage')
+  await inspector.post('HeapProfiler.collectGarbage')
+  const result = await evaluate('references.filter(ref => ref.deref() !== undefined).length')
+  console.log(result.result.value)
+} finally {
+  inspector.disconnect()
+}

--- a/packages/memory-leak-finder/test/fixtures/container-size-gc.mjs
+++ b/packages/memory-leak-finder/test/fixtures/container-size-gc.mjs
@@ -23,7 +23,7 @@ try {
   await inspector.post('HeapProfiler.collectGarbage')
   await inspector.post('HeapProfiler.collectGarbage')
   const result = await evaluate('references.filter(ref => ref.deref() !== undefined).length')
-  console.log(result.result.value)
+  process.stdout.write(`${result.result.value}\n`)
 } finally {
   inspector.disconnect()
 }


### PR DESCRIPTION
`mapSize` and `setSize` query every live container through the debugger, but the query result arrays are never released. Those arrays keep the measured maps and sets alive after the application drops them, contaminating subsequent memory measurements.

Give each query its own object group and release it in `finally`, including when prototype lookup, querying, or size calculation fails.

A real Node inspector reproduction creates ten containers, measures their size, drops the application references, and forces GC. Before this change, all ten maps or sets survive; after it, zero survive, matching the unmeasured control. The new subprocess tests cover that behavior, alongside error-path and release-order unit tests.

Validation: 352 tests passed (four existing skips) in the memory-leak-finder package, package TypeScript check passed, and changed files pass Prettier.
