### PR TITLE
fix: preserve numeric heap snapshot edge indices

### DIFF
--- a/packages/heap-snapshot-worker/src/parts/CreateHeapSnapshotNode/CreateHeapSnapshotNode.ts
+++ b/packages/heap-snapshot-worker/src/parts/CreateHeapSnapshotNode/CreateHeapSnapshotNode.ts
@@ -23,7 +23,9 @@ export const createHeapSnapshotNode = (
         break
       }
       case nameKey: {
-        node[key] = strings[value]
+        const type = nameKey === 'nameOrIndex' ? valueTypes[array[startIndex + nodeFields.indexOf(typeKey)]] : undefined
+        // V8 stores numeric indices for element and hidden edges, not string-table offsets.
+        node[key] = type === 'element' || type === 'hidden' ? value : strings[value]
 
         break
       }

--- a/packages/heap-snapshot-worker/src/parts/CreateNameMap/CreateNameMap.ts
+++ b/packages/heap-snapshot-worker/src/parts/CreateNameMap/CreateNameMap.ts
@@ -12,7 +12,7 @@ export const createNameMap = (parsedNodes: readonly CleanedNode[], graph: HeapSn
     for (const edge of edges) {
       const toNode = parsedNodes[edge.index]
       nameMap[toNode.id] ||= {
-        edgeName: edge.name,
+        edgeName: String(edge.name),
         nodeName: toNode.name,
       }
     }

--- a/packages/heap-snapshot-worker/src/parts/GetPrototypeChainAnalysisFromHeapSnapshot/GetPrototypeChainAnalysisFromHeapSnapshot.ts
+++ b/packages/heap-snapshot-worker/src/parts/GetPrototypeChainAnalysisFromHeapSnapshot/GetPrototypeChainAnalysisFromHeapSnapshot.ts
@@ -12,7 +12,7 @@ export interface ParsedNode {
 }
 
 export interface ParsedEdge {
-  readonly nameOrIndex: string
+  readonly nameOrIndex: string | number
   readonly toNode: number
   readonly type: string
 }
@@ -260,7 +260,7 @@ const analyzeNodePrototypeChain = (
         const prototypeEdges = edgeMap.get(prototypeNode.id) || []
         for (const edge of prototypeEdges) {
           // Only check property-type edges for suspicious properties
-          if (edge.type === 'property' && isUnusualPrototypeProperty(edge.nameOrIndex)) {
+          if (edge.type === 'property' && typeof edge.nameOrIndex === 'string' && isUnusualPrototypeProperty(edge.nameOrIndex)) {
             prototypeProperties.push({
               propertyName: edge.nameOrIndex,
               prototypeId: prototypeNode.id,

--- a/packages/heap-snapshot-worker/src/parts/Snapshot/Snapshot.ts
+++ b/packages/heap-snapshot-worker/src/parts/Snapshot/Snapshot.ts
@@ -18,7 +18,7 @@ export interface CleanedNode {
 }
 
 export interface ParsedEdge extends HeapSnapshotRecord {
-  readonly nameOrIndex: string
+  readonly nameOrIndex: string | number
   readonly toNode: number
   readonly type: string
 }

--- a/packages/heap-snapshot-worker/test/CreateNameMap.test.ts
+++ b/packages/heap-snapshot-worker/test/CreateNameMap.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from '@jest/globals'
+import { createNameMap } from '../src/parts/CreateNameMap/CreateNameMap.ts'
+
+test('keeps index zero as a display name instead of falling back to Array', () => {
+  const nodes = [
+    { id: 1, name: 'Array', type: 'object' },
+    { id: 2, name: 'Array', type: 'object' },
+  ]
+  const names = createNameMap(nodes, { 1: [{ index: 1, name: 0 }], 2: [] })
+  expect(names[2].edgeName || names[2].nodeName).toBe('0')
+})

--- a/packages/heap-snapshot-worker/test/ParseHeapSnapshotInternalEdges.test.ts
+++ b/packages/heap-snapshot-worker/test/ParseHeapSnapshotInternalEdges.test.ts
@@ -9,9 +9,22 @@ test('single node', () => {
   const nodeFieldCount = 7
   expect(ParseHeapSnapshotInternalEdges.parseHeapSnapshotInternalEdges(edges, edgeFields, edgeTypes, nodeFieldCount, strings)).toEqual([
     {
-      nameOrIndex: 'a',
+      nameOrIndex: 0,
       toNode: 1,
       type: 'element',
     },
+  ])
+})
+
+test('preserves numeric element and hidden indices while resolving named edge strings', () => {
+  const edgeFields = ['to_node', 'name_or_index', 'type']
+  const edgeTypes = ['property', 'hidden', 'element', 'internal']
+  const edges = [7, 1, 2, 14, 1, 1, 21, 1, 0, 28, 1, 3]
+  const strings = ['unrelated', 'tabs']
+  expect(ParseHeapSnapshotInternalEdges.parseHeapSnapshotInternalEdges(edges, edgeFields, edgeTypes, 7, strings)).toEqual([
+    { toNode: 1, nameOrIndex: 1, type: 'element' },
+    { toNode: 2, nameOrIndex: 1, type: 'hidden' },
+    { toNode: 3, nameOrIndex: 'tabs', type: 'property' },
+    { toNode: 4, nameOrIndex: 'tabs', type: 'internal' },
   ])
 })


### PR DESCRIPTION
Heap snapshots store numeric indices for `element` and `hidden` edges. The parser treated those indices as string-table offsets, so array reports could show unrelated source text, environment names, or error messages as array names.

Keep those two edge types numeric when creating each parsed record, preserve index zero when choosing display names, and update the shared edge types and prototype-analysis consumer.

This surfaced while investigating a pty-host workspace-layout leak. Reprocessing the same two real snapshots reduces the named-array difference report from 118 rows to 12 by grouping indexed references under their actual indices. The independently verified `tabs` growth remains unchanged: six arrays, delta +5.

Regression tests cover zero, hidden indices, named properties, reordered metadata, and display-name fallback. Validation: 411 tests passed, 21 existing skips; heap-snapshot-worker TypeScript and changed-file Prettier checks passed.
