### PR TITLE
feat: chart named array count differences

### DIFF
--- a/packages/charts/src/parts/Charts/Charts.ts
+++ b/packages/charts/src/parts/Charts/Charts.ts
@@ -1,6 +1,7 @@
 export * as AbortControllerCount from '../CreateAbortControllerCountChart/CreateAbortControllerCountChart.ts'
 export * as AbortSignalCount from '../CreateAbortSignalCountChart/CreateAbortSignalCountChart.ts'
 export * as ArrayCount from '../CreateArrayCountChart/CreateArrayCountChart.ts'
+export * as NamedArrayCountDifference from '../CreateNamedArrayCountDifferenceChart/CreateNamedArrayCountDifferenceChart.ts'
 export * as ArrayElementCount from '../CreateArrayElementCountChart/CreateArrayElementCountChart.ts'
 export * as AttachedDomNodeCount from '../CreateAttachedDomNodeCountChart/CreateAttachedDomNodeCountChart.ts'
 export * as BrowserPerformanceCounters from '../CreateBrowserPerformanceCountersChart/CreateBrowserPerformanceCountersChart.ts'

--- a/packages/charts/src/parts/CreateNamedArrayCountDifferenceChart/CreateNamedArrayCountDifferenceChart.ts
+++ b/packages/charts/src/parts/CreateNamedArrayCountDifferenceChart/CreateNamedArrayCountDifferenceChart.ts
@@ -1,0 +1,17 @@
+import { getNamedArrayCountDifferenceData } from '../GetNamedArrayCountDifferenceData/GetNamedArrayCountDifferenceData.ts'
+
+export const name = 'named-array-count-difference'
+export const getData = getNamedArrayCountDifferenceData
+export const multiple = true
+
+export const createChart = () => ({
+  fontSize: 12,
+  marginLeft: 500,
+  marginRight: 500,
+  type: 'dual-bar-chart',
+  width: 1400,
+  x: 'index',
+  xLabel: 'Index',
+  y: 'count',
+  yLabel: 'Array Counts',
+})

--- a/packages/charts/src/parts/GetNamedArrayCountDifferenceData/GetNamedArrayCountDifferenceData.ts
+++ b/packages/charts/src/parts/GetNamedArrayCountDifferenceData/GetNamedArrayCountDifferenceData.ts
@@ -1,0 +1,31 @@
+import { existsSync } from 'node:fs'
+import { readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import { readJson } from '../ReadJson/ReadJson.ts'
+
+interface ArrayCountRow {
+  readonly count: number
+  readonly delta: number
+  readonly name: string
+}
+
+export const getNamedArrayCountDifferenceData = async (basePath: string) => {
+  const resultsPath = join(basePath, 'namedArrayCountDifference')
+  if (!existsSync(resultsPath)) {
+    return []
+  }
+  const entries = await readdir(resultsPath, { withFileTypes: true })
+  const results = []
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) {
+      continue
+    }
+    const rawData = await readJson(join(resultsPath, entry.name))
+    const rows: readonly ArrayCountRow[] = rawData.namedArrayCountDifference || []
+    results.push({
+      data: rows.map(({ count, delta, name }) => ({ count, delta, name })).sort((a, b) => b.count - a.count),
+      filename: entry.name.slice(0, -'.json'.length),
+    })
+  }
+  return results
+}

--- a/packages/charts/test/NamedArrayCountDifferenceChart.test.ts
+++ b/packages/charts/test/NamedArrayCountDifferenceChart.test.ts
@@ -1,0 +1,45 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, test } from '@jest/globals'
+import * as Charts from '../src/parts/Charts/Charts.ts'
+import * as Chart from '../src/parts/CreateNamedArrayCountDifferenceChart/CreateNamedArrayCountDifferenceChart.ts'
+
+test('registers a per-scenario array count and delta chart', () => {
+  expect(Charts.NamedArrayCountDifference).toBe(Chart)
+  expect(Chart.multiple).toBe(true)
+  expect(Chart.name).toBe('named-array-count-difference')
+  expect(Chart.createChart()).toMatchObject({ type: 'dual-bar-chart', yLabel: 'Array Counts' })
+})
+
+test('preserves all rows, sorts counts, and keeps empty results empty', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'named-array-chart-'))
+  const resultsPath = join(root, 'namedArrayCountDifference')
+  try {
+    await expect(Chart.getData(root)).resolves.toEqual([])
+    await mkdir(join(resultsPath, 'unrelated-directory'), { recursive: true })
+    await writeFile(join(resultsPath, 'unrelated.log'), 'not JSON')
+    await writeFile(
+      join(resultsPath, 'before.json'),
+      JSON.stringify({
+        namedArrayCountDifference: [
+          { name: 'tabs', count: 38, delta: 37 },
+          { name: 'listeners', count: 50, delta: 1 },
+        ],
+      }),
+    )
+    await writeFile(join(resultsPath, 'after.json'), JSON.stringify({ namedArrayCountDifference: [] }))
+    await expect(Chart.getData(root)).resolves.toEqual([
+      { data: [], filename: 'after' },
+      {
+        data: [
+          { name: 'listeners', count: 50, delta: 1 },
+          { name: 'tabs', count: 38, delta: 37 },
+        ],
+        filename: 'before',
+      },
+    ])
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
Add `build-charts` support for `namedArrayCountDifference`, including per-scenario count/growth charts in renderer, main, extension-host, and pty-host result directories.

This is useful for leaks in plain arrays that named callback counts do not reveal. A real pty-host window-lifecycle investigation produces `tabs` array growth; the adapter renders that result using the existing dual-bar chart and before/after highlighting pipeline.

Preserve every reported row and its count/delta, keep empty results empty, and ignore non-JSON files and directories. Tests cover those cases and chart registration. `npm run build-charts` generated a complete 12-row SVG from the real five-cycle heap comparison.

Validation: both new tests and package TypeScript/Prettier checks pass. The whole chart suite passes 48 of 49 tests; its existing `TrackedAllocationsChart` expectation omits `omittedEntryCount: 0` and fails identically with unchanged chart code on the base revision.
